### PR TITLE
top menu tabs fix

### DIFF
--- a/.pages
+++ b/.pages
@@ -3,5 +3,4 @@ nav:
  - build
  - infrastructure
  - learn
- - infrastructure
  - tutorials


### PR DESCRIPTION
### Description

After last merge there was a duplicate tab in the top menu bar. "Infrastructure" was duplicated. This PR fixes that issue.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
