### PR TITLE
updated supported networks styling

### DIFF
--- a/.snippets/text/supported-networks.md
+++ b/.snippets/text/supported-networks.md
@@ -1,4 +1,367 @@
 <!-- The content in this file is auto-generated. Do not modify this file directly. Please see the README.md in the wormhole-mkdocs/scripts directory to learn how to update this page. -->
 <!--SUPPORTED_BLOCKCHAIN_CARDS-->
-<table data-view="cards" data-full-width="false"><thead><th></th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></thead><tbody><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#acala"><strong>Acala</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/acala.webp" alt="Acala" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/algorand#algorand"><strong>Algorand</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/algorand.webp" alt="Algorand" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/aptos#aptos"><strong>Aptos</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/aptos.webp" alt="Aptos" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#arbitrum"><strong>Arbitrum</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/arbitrum.webp" alt="Arbitrum" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#avalanche"><strong>Avalanche</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/avalanche.webp" alt="Avalanche" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#base"><strong>Base</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/base.webp" alt="Base" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#berachain"><strong>Berachain</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/berachain.webp" alt="Berachain" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#blast"><strong>Blast</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/blast.webp" alt="Blast" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#bsc"><strong>BNB Smart Chain</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/bsc.webp" alt="BNB Smart Chain" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#celestia"><strong>Celestia</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/celestia.webp" alt="Celestia" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#celo"><strong>Celo</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/celo.webp" alt="Celo" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#cosmoshub"><strong>Cosmoshub</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/cosmoshub.webp" alt="Cosmoshub" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#dymension"><strong>Dymension</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/dymension.webp" alt="Dymension" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#ethereum"><strong>Ethereum</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/ethereum.webp" alt="Ethereum" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#evmos"><strong>Evmos</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/evmos.webp" alt="Evmos" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#fantom"><strong>Fantom</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/fantom.webp" alt="Fantom" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#gnosis"><strong>Gnosis</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/gnosis.webp" alt="Gnosis" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#injective"><strong>Injective</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/injective.webp" alt="Injective" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#karura"><strong>Karura</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/karura.webp" alt="Karura" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#klaytn"><strong>Klaytn</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/klaytn.webp" alt="Klaytn" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#kujira"><strong>Kujira</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/kujira.webp" alt="Kujira" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#linea"><strong>Linea</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/linea.webp" alt="Linea" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#mantle"><strong>Mantle</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/mantle.webp" alt="Mantle" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#moonbeam"><strong>Moonbeam</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/moonbeam.webp" alt="Moonbeam" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/near#near"><strong>NEAR</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/near.webp" alt="NEAR" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#neon"><strong>Neon</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/neon.webp" alt="Neon" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#neutron"><strong>Neutron</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/neutron.webp" alt="Neutron" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#oasis"><strong>Oasis</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/oasis.webp" alt="Oasis" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#optimism"><strong>Optimism</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/optimism.webp" alt="Optimism" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#osmosis"><strong>Osmosis</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/osmosis.webp" alt="Osmosis" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#polygon"><strong>Polygon</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/polygon.webp" alt="Polygon" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#provenance"><strong>Provenance</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/provenance.webp" alt="Provenance" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/solana#pythnet"><strong>Pythnet</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/pythnet.webp" alt="Pythnet" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#rootstock"><strong>Rootstock</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/rootstock.webp" alt="Rootstock" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#scroll"><strong>Scroll</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/scroll.webp" alt="Scroll" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#seda"><strong>Seda</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/seda.webp" alt="Seda" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#sei"><strong>Sei</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/sei.webp" alt="Sei" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#seievm"><strong>Seievm</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/seievm.webp" alt="Seievm" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/solana#solana"><strong>Solana</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/solana.webp" alt="Solana" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#stargaze"><strong>Stargaze</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/stargaze.webp" alt="Stargaze" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/sui#sui"><strong>Sui</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/sui.webp" alt="Sui" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#terra"><strong>Terra</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/terra.webp" alt="Terra" style="width:90px; height:auto;"></a></td></tr><tr><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#terra2"><strong>Terra2</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/terra2.webp" alt="Terra2" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/evm#xlayer"><strong>Xlayer</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/xlayer.webp" alt="Xlayer" style="width:90px; height:auto;"></a></td><td style="vertical-align: top; text-align: center;"><a href="/build/start-building/supported-networks/cosmos#xpla"><strong>Xpla</strong><br><img class="no-lightbox" src="/images/build/start-building/supported-networks/xpla.webp" alt="Xpla" style="width:90px; height:auto;"></a></td></tr></tbody></table>
+
+<div class="card-container" markdown>
+
+<div class="faucet" markdown>
+
+<strong>Acala</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#acala"><img class="no-lightbox" src="/images/build/start-building/supported-networks/acala.webp" alt="Acala" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Algorand</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/algorand#algorand"><img class="no-lightbox" src="/images/build/start-building/supported-networks/algorand.webp" alt="Algorand" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Aptos</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/aptos#aptos"><img class="no-lightbox" src="/images/build/start-building/supported-networks/aptos.webp" alt="Aptos" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Arbitrum</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#arbitrum"><img class="no-lightbox" src="/images/build/start-building/supported-networks/arbitrum.webp" alt="Arbitrum" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Avalanche</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#avalanche"><img class="no-lightbox" src="/images/build/start-building/supported-networks/avalanche.webp" alt="Avalanche" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Base</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#base"><img class="no-lightbox" src="/images/build/start-building/supported-networks/base.webp" alt="Base" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Berachain</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#berachain"><img class="no-lightbox" src="/images/build/start-building/supported-networks/berachain.webp" alt="Berachain" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Blast</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#blast"><img class="no-lightbox" src="/images/build/start-building/supported-networks/blast.webp" alt="Blast" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>BNB Smart Chain</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#bsc"><img class="no-lightbox" src="/images/build/start-building/supported-networks/bsc.webp" alt="BNB Smart Chain" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Celestia</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#celestia"><img class="no-lightbox" src="/images/build/start-building/supported-networks/celestia.webp" alt="Celestia" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Celo</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#celo"><img class="no-lightbox" src="/images/build/start-building/supported-networks/celo.webp" alt="Celo" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Cosmoshub</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#cosmoshub"><img class="no-lightbox" src="/images/build/start-building/supported-networks/cosmoshub.webp" alt="Cosmoshub" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Dymension</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#dymension"><img class="no-lightbox" src="/images/build/start-building/supported-networks/dymension.webp" alt="Dymension" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Ethereum</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#ethereum"><img class="no-lightbox" src="/images/build/start-building/supported-networks/ethereum.webp" alt="Ethereum" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Evmos</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#evmos"><img class="no-lightbox" src="/images/build/start-building/supported-networks/evmos.webp" alt="Evmos" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Fantom</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#fantom"><img class="no-lightbox" src="/images/build/start-building/supported-networks/fantom.webp" alt="Fantom" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Gnosis</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#gnosis"><img class="no-lightbox" src="/images/build/start-building/supported-networks/gnosis.webp" alt="Gnosis" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Injective</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#injective"><img class="no-lightbox" src="/images/build/start-building/supported-networks/injective.webp" alt="Injective" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Karura</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#karura"><img class="no-lightbox" src="/images/build/start-building/supported-networks/karura.webp" alt="Karura" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Klaytn</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#klaytn"><img class="no-lightbox" src="/images/build/start-building/supported-networks/klaytn.webp" alt="Klaytn" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Kujira</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#kujira"><img class="no-lightbox" src="/images/build/start-building/supported-networks/kujira.webp" alt="Kujira" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Linea</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#linea"><img class="no-lightbox" src="/images/build/start-building/supported-networks/linea.webp" alt="Linea" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Mantle</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#mantle"><img class="no-lightbox" src="/images/build/start-building/supported-networks/mantle.webp" alt="Mantle" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Moonbeam</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#moonbeam"><img class="no-lightbox" src="/images/build/start-building/supported-networks/moonbeam.webp" alt="Moonbeam" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>NEAR</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/near#near"><img class="no-lightbox" src="/images/build/start-building/supported-networks/near.webp" alt="NEAR" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Neon</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#neon"><img class="no-lightbox" src="/images/build/start-building/supported-networks/neon.webp" alt="Neon" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Neutron</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#neutron"><img class="no-lightbox" src="/images/build/start-building/supported-networks/neutron.webp" alt="Neutron" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Oasis</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#oasis"><img class="no-lightbox" src="/images/build/start-building/supported-networks/oasis.webp" alt="Oasis" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Optimism</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#optimism"><img class="no-lightbox" src="/images/build/start-building/supported-networks/optimism.webp" alt="Optimism" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Osmosis</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#osmosis"><img class="no-lightbox" src="/images/build/start-building/supported-networks/osmosis.webp" alt="Osmosis" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Polygon</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#polygon"><img class="no-lightbox" src="/images/build/start-building/supported-networks/polygon.webp" alt="Polygon" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Provenance</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#provenance"><img class="no-lightbox" src="/images/build/start-building/supported-networks/provenance.webp" alt="Provenance" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Pythnet</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/solana#pythnet"><img class="no-lightbox" src="/images/build/start-building/supported-networks/pythnet.webp" alt="Pythnet" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Rootstock</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#rootstock"><img class="no-lightbox" src="/images/build/start-building/supported-networks/rootstock.webp" alt="Rootstock" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Scroll</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#scroll"><img class="no-lightbox" src="/images/build/start-building/supported-networks/scroll.webp" alt="Scroll" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Seda</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#seda"><img class="no-lightbox" src="/images/build/start-building/supported-networks/seda.webp" alt="Seda" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Sei</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#sei"><img class="no-lightbox" src="/images/build/start-building/supported-networks/sei.webp" alt="Sei" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Seievm</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#seievm"><img class="no-lightbox" src="/images/build/start-building/supported-networks/seievm.webp" alt="Seievm" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Solana</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/solana#solana"><img class="no-lightbox" src="/images/build/start-building/supported-networks/solana.webp" alt="Solana" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Stargaze</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#stargaze"><img class="no-lightbox" src="/images/build/start-building/supported-networks/stargaze.webp" alt="Stargaze" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Sui</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/sui#sui"><img class="no-lightbox" src="/images/build/start-building/supported-networks/sui.webp" alt="Sui" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Terra</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#terra"><img class="no-lightbox" src="/images/build/start-building/supported-networks/terra.webp" alt="Terra" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Terra2</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#terra2"><img class="no-lightbox" src="/images/build/start-building/supported-networks/terra2.webp" alt="Terra2" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Xlayer</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/evm#xlayer"><img class="no-lightbox" src="/images/build/start-building/supported-networks/xlayer.webp" alt="Xlayer" style="width:90px; height:auto;"></a>
+
+</div>
+
+<div class="faucet" markdown>
+
+<strong>Xpla</strong>
+<br><br>
+<a href="/build/start-building/supported-networks/cosmos#xpla"><img class="no-lightbox" src="/images/build/start-building/supported-networks/xpla.webp" alt="Xpla" style="width:90px; height:auto;"></a>
+
+</div>
+</div>
+  
 <!--SUPPORTED_BLOCKCHAIN_CARDS-->


### PR DESCRIPTION
### Description

This PR updates the styling of the Supported Networks snippet. Instead of a table, a grid is now used (similarly to the TestNet faucets page).

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️

