### PR TITLE
Fix toolkit link to the sdk

### DIFF
--- a/build/toolkit/.pages
+++ b/build/toolkit/.pages
@@ -3,5 +3,5 @@ nav:
  - index.md
  - 'Wormholescan': 'https://wormholescan.io/'
  - 'Wormhole CLI' : 'cli.md'
- - 'Wormhole SDK' : 'wormhole-sdk.md'
+ - 'Wormhole SDK' : '/docs/build/applications/wormhole-sdk/'
  - 'Tilt': 'tilt.md'


### PR DESCRIPTION
### Description

Fix toolkit link to the sdk

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
