### PR TITLE
updated vaa parser link

### DIFF
--- a/build/toolkit/index.md
+++ b/build/toolkit/index.md
@@ -63,6 +63,6 @@ Regardless of which network development environment you are using, there are a f
 
     The VAA Parser is a resource for parsing out details of an encoded VAA.
 
-    [:octicons-arrow-right-16: Try the VAA Parser](https://vaa.dev/#/parse){target=\_blank}
+    [:octicons-arrow-right-16: Try the VAA Parser](https://wormholescan.io/#/developers/vaa-parser){target=\_blank}
 
 </div>


### PR DESCRIPTION
### Description

Fixed link redirecting to VAA parser. New link:
https://wormholescan.io/#/developers/vaa-parser

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
