### PR TITLE
contract addresses reference

### DIFF
--- a/tutorials/messaging/cross-chain-contracts.md
+++ b/tutorials/messaging/cross-chain-contracts.md
@@ -192,7 +192,7 @@ Both deployment scripts, `deploySender.js` and `deployReceiver.js`, perform the 
         ```
 
     !!! note
-        The `chains.json` file contains the configuration details for the Avalanche Fuji and Celo Alfajores TestNets. You can modify this file to add more networks if needed.
+        The `chains.json` file contains the configuration details for the Avalanche Fuji and Celo Alfajores TestNets. You can modify this file to add more networks if needed. For a complete list of contract addresses, visit the [reference page](/docs/build/reference/){target=\_blank}.
 
 2. **Set up provider and wallet** - the scripts establish a connection to the blockchain using a provider and create a wallet instance using a private key. This wallet is responsible for signing the deployment transaction
 


### PR DESCRIPTION
### Description

Based on WH feedback, I added a link to the [reference page](https://wormhole.com/docs/build/reference/) in the tutorial, where users can check the complete list of contract addresses.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
