### PR TITLE
updated code snippets in connect configurations

### DIFF
--- a/build/applications/connect/configuration.md
+++ b/build/applications/connect/configuration.md
@@ -84,10 +84,9 @@ For further details on the `route` plugin interface, refer to the [Wormhole Type
 To configure Wormhole Connect to offer only USDC transfers via the CCTP route, use the following configuration:
 
 ```typescript
-import {
+import WormholeConnect, {
   AutomaticCCTPRoute,
   WormholeConnectConfig,
-  WormholeConnect,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: WormholeConnectConfig = {
@@ -102,12 +101,11 @@ const config: WormholeConnectConfig = {
 In this example, Wormhole Connect is configured with routes for both default protocols (Token Bridge and CCTP), as well as third-party protocols like [Native Token Transfers (NTT)](/docs/build/contract-integrations/native-token-transfers/){target=\_blank} and [Mayan Swap](https://swap.mayan.finance/){target=\_blank}.
 
 ```typescript
-import {
+import WormholeConnect, {
   DEFAULT_ROUTES,
   nttRoutes,
   MayanRouteSWIFT,
   WormholeConnectConfig,
-  WormholeConnect,
 } from '@wormhole-foundation/wormhole-connect';
 
 import { myNttConfig } from './consts'; // Custom NTT configuration

--- a/build/applications/connect/upgrade.md
+++ b/build/applications/connect/upgrade.md
@@ -162,10 +162,9 @@ Now that you know the available `route` plugins, let's explore some examples of 
 To configure Wormhole Connect to offer only USDC transfers via the CCTP route, use the following configuration:
 
 ```typescript
-import {
+import WormholeConnect, {
   AutomaticCCTPRoute,
   WormholeConnectConfig,
-  WormholeConnect,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: WormholeConnectConfig = {
@@ -180,12 +179,11 @@ const config: WormholeConnectConfig = {
 In this example, Wormhole Connect is configured with routes for both default protocols (Token Bridge & CCTP), as well as third-party protocols like [Native Token Transfers (NTT)](/docs/build/contract-integrations/native-token-transfers/){target=\_blank} and [Mayan Swap](https://swap.mayan.finance/){target=\_blank}.
 
 ```typescript
-import {
+import WormholeConnect, {
   DEFAULT_ROUTES,
   nttRoutes,
   MayanRouteSWIFT,
   WormholeConnectConfig,
-  WormholeConnect,
 } from '@wormhole-foundation/wormhole-connect';
 
 import { myNttConfig } from './consts'; // Custom NTT configuration
@@ -214,7 +212,9 @@ Key Changes to `tokensConfig`:
     In the old structure, the `foreignAssets` field defined the token’s presence on other chains, and `decimals` were mapped across multiple chains.
 
     ```typescript
-    import WormholeConnect from '@wormhole-foundation/wormhole-connect';
+    import WormholeConnect, {
+      WormholeConnectConfig,
+    } from '@wormhole-foundation/wormhole-connect';
 
     const config: WormholeConnectConfig = {
       tokensConfig: {
@@ -226,7 +226,7 @@ Key Changes to `tokensConfig`:
           tokenId: {
             chain: 'ethereum',
             address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
-            },
+          },
           coinGeckoId: 'ethereum',
           color: '#62688F',
           decimals: { Ethereum: 18, default: 8 },
@@ -245,7 +245,9 @@ Key Changes to `tokensConfig`:
     In v1.0, `foreignAssets` has been replaced with `wrappedTokens`, simplifying token transfers across chains by directly mapping wrapped token addresses. The `decimals` value is now a simple number representing the token’s decimals on its native chain.
 
     ```typescript
-    import WormholeConnect from '@wormhole-foundation/wormhole-connect';
+    import WormholeConnect, {
+      WormholeConnectConfig,
+    } from '@wormhole-foundation/wormhole-connect';
 
     const config: WormholeConnectConfig = {
       tokensConfig: {
@@ -290,6 +292,7 @@ This change simplifies the configuration process by providing a cleaner, more fl
     ```typescript
     import WormholeConnect, {
       nttRoutes,
+      WormholeConnectConfig,
     } from '@wormhole-foundation/wormhole-connect';
 
     const config: WormholeConnectConfig = {
@@ -330,6 +333,7 @@ This change simplifies the configuration process by providing a cleaner, more fl
     ```typescript
     import WormholeConnect, {
       nttRoutes,
+      WormholeConnectConfig,
     } from '@wormhole-foundation/wormhole-connect';
 
     const config: WormholeConnectConfig = {
@@ -397,7 +401,9 @@ Additionally, there are two new properties under `ui`:
  - **`ui.getHelpUrl`** - URL that Connect will render when an unknown error occurs, allowing users to seek help. This can link to a Discord server or any other support channel
 
 ```typescript
-import WormholeConnect from '@wormhole-foundation/wormhole-connect';
+import WormholeConnect, {
+  WormholeConnectConfig,
+} from '@wormhole-foundation/wormhole-connect';
 
 const config: WormholeConnectConfig = {
   ui: {


### PR DESCRIPTION
### Description

I have updated code snippets from the Connect Configuration and Migration pages. The `WormholeConnect` component was imported incorrectly. 

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
