### PR TITLE
Target Attribute Formatting in Update cctp.md

### DIFF
--- a/learn/messaging/cctp.md
+++ b/learn/messaging/cctp.md
@@ -5,7 +5,7 @@ description: Unlock fast USDC transfers with Wormhole's integration of Circle's 
 
 # Circle's CCTP Bridge
 
-Wormhole Connect and the Wormhole TypeScript SDK support fast, cheap, native USDC bridging between all networks supported by Circle's [Cross-Chain Transfer Protocol](https://www.circle.com/en/cross-chain-transfer-protocol){target=\_blank}. CCTP is Circle's native USDC cross-chain transfer attestation service.
+Wormhole Connect and the Wormhole TypeScript SDK support fast, cheap, native USDC bridging between all networks supported by Circle's [Cross-Chain Transfer Protocol](https://www.circle.com/en/cross-chain-transfer-protocol){target="_blank"}. CCTP is Circle's native USDC cross-chain transfer attestation service.
 
 While this protocol is wholly separate from Wormhole itself, Wormhole builds on top of CCTP and adds several valuable augmentations, making it more straightforward to use and more useful for end users. These features include:
 
@@ -14,15 +14,15 @@ While this protocol is wholly separate from Wormhole itself, Wormhole builds on 
 - **Gas drop off** - enables users to convert a portion of USDC into the destination chain's gas token upon a successful transfer
 
 !!! note
-    Wormhole supports all CCTP-supported chains but at the moment only a [handful of chains](https://developers.circle.com/stablecoins/docs/supported-domains){target=\_blank} are supported by Circle.
+    Wormhole supports all CCTP-supported chains but at the moment only a [handful of chains](https://developers.circle.com/stablecoins/docs/supported-domains){target="_blank"} are supported by Circle.
 
-You can use Wormhole's CCTP-powered USDC bridging by embedding the [Connect Widget](/docs/build/applications/connect/overview/){target=\_blank} or by integrating the [TypeScript SDK](/docs/build/applications/wormhole-sdk/){target=\_blank} directly.
+You can use Wormhole's CCTP-powered USDC bridging by embedding the [Connect Widget](/docs/build/applications/connect/overview/){target="_blank"} or by integrating the [TypeScript SDK](/docs/build/applications/wormhole-sdk/){target="_blank"} directly.
 
 ## Automatic Relaying
 
-To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/stablecoins/reference/getattestation){target=\_blank} must be delivered to the destination chain.
+To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/stablecoins/reference/getattestation){target="_blank"} must be delivered to the destination chain.
 
-This attestation delivery may be difficult or impossible in some contexts. For example, in a browser context, the user doesn't wish to wait for finality to deliver the attestation. To address this difficulty, the Wormhole CCTP relayer may be used either with the [Wormhole Connect Widget](/docs/build/applications/connect/overview/){target=\_blank} or more directly with the [Wormhole TypeScript SDK](/docs/build/applications/wormhole-sdk/){target=\_blank}.
+This attestation delivery may be difficult or impossible in some contexts. For example, in a browser context, the user doesn't wish to wait for finality to deliver the attestation. To address this difficulty, the Wormhole CCTP relayer may be used either with the [Wormhole Connect Widget](/docs/build/applications/connect/overview/){target="_blank"} or more directly with the [Wormhole TypeScript SDK](/docs/build/applications/wormhole-sdk/){target="_blank"}.
 
 The Wormhole CCTP Relayer charges a fee to deliver the attestation and complete the transfer.
 


### PR DESCRIPTION
### Description

**Target Attribute Formatting**:

The target attribute in links is formatted as `{target=\_blank}`, but it should be `{target="_blank"}` with quotes around `_blank`. This is not an orthographic error but a syntax issue that could lead to unexpected behavior in HTML.

Fixed.

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
