### PR TITLE
added relevant comment related to Solana deployment version

### DIFF
--- a/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-solana.md
+++ b/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-solana.md
@@ -113,6 +113,9 @@ In this step, you'll set SPL token mint authority to the newly generated token a
 spl-token authorize INSERT_TOKEN_ADDRESS mint INSERT_DERIVED_PDA
 ```
 
+!!! note
+    Please ensure that you are using Anchor CLI version `0.29.0`. Running the deployment with a different version may cause compatibility issues.
+
 If deploying to Solana in `burning` mode, set the mint authority for your SPL token to the NTT program ID you generated in the previous step.
 
 ### Deploy NTT


### PR DESCRIPTION
### Description

I tried deploying the NTT program for Solana following the documentation and encountered a specific Anchor version error (see the image below). I have added a relevant note to the docs.

<img width="624" alt="CLI-version-error" src="https://github.com/user-attachments/assets/f23416a5-1f7b-4679-a3ec-33519d460652">

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
