### PR TITLE
update ntt links

### DIFF
--- a/build/applications/connect/configuration.md
+++ b/build/applications/connect/configuration.md
@@ -75,7 +75,7 @@ The `@wormhole-foundation/wormhole-connect` package offers a variety of `route` 
 - **`MayanRouteMCTP`** - route for Mayan’s MCTP protocol only
 - **`MayanRouteWH`** - route for Mayan’s original Wormhole transfer protocol
 
-In addition to these routes, developers can create custom routes for their Wormhole-based protocols. For examples, refer to the [NTT](https://github.com/wormhole-foundation/example-native-token-transfers/tree/main/sdk/route){target=\_blank} and the [Mayan](https://github.com/mayan-finance/wormhole-sdk-route){target=\_blank} example GitHub repositories.
+In addition to these routes, developers can create custom routes for their Wormhole-based protocols. For examples, refer to the [NTT](https://github.com/wormhole-foundation/native-token-transfers/tree/main/sdk/route){target=\_blank} and the [Mayan](https://github.com/mayan-finance/wormhole-sdk-route){target=\_blank} example GitHub repositories.
 
 For further details on the `route` plugin interface, refer to the [Wormhole TypeScript SDK route code](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/route.ts){target=\_blank}.
 

--- a/build/applications/connect/routes.md
+++ b/build/applications/connect/routes.md
@@ -39,7 +39,7 @@ Trustless relayers can execute the second transaction on the user's behalf. Ther
 
 ## Native Token Transfers (NTT) Routes {: #native-token-transfers-ntt-routes}
 
-[Wormhole's Native Token Transfer (NTT) framework](https://github.com/wormhole-foundation/example-native-token-transfers/){target=\_blank} enables token issuers to retain full ownership of their tokens across any number of chains, unlike the Token Bridge. The token issuer must deploy NTT contracts, and Wormhole Connect needs to be [configured](/docs/build/applications/connect/configuration/){target=\_blank} with the appropriate `nttGroups` before such tokens are recognized as transferrable via NTT. Refer to the [documentation in the NTT repository](https://github.com/wormhole-foundation/example-native-token-transfers?tab=readme-ov-file#overview){target=\_blank} for more information about the contracts needed and the framework in general.
+[Wormhole's Native Token Transfer (NTT) framework](https://github.com/wormhole-foundation/native-token-transfers/){target=\_blank} enables token issuers to retain full ownership of their tokens across any number of chains, unlike the Token Bridge. The token issuer must deploy NTT contracts, and Wormhole Connect needs to be [configured](/docs/build/applications/connect/configuration/){target=\_blank} with the appropriate `nttGroups` before such tokens are recognized as transferrable via NTT. Refer to the [documentation in the NTT repository](https://github.com/wormhole-foundation/native-token-transfers?tab=readme-ov-file#overview){target=\_blank} for more information about the contracts needed and the framework in general.
 
 #### Manual Route {: #manual-route-ntt}
 

--- a/build/applications/connect/upgrade.md
+++ b/build/applications/connect/upgrade.md
@@ -151,7 +151,7 @@ The `@wormhole-foundation/wormhole-connect` package offers a variety of `route` 
     - **`MayanRouteMCTP`** - route for Mayan’s MCTP protocol only
     - **`MayanRouteWH`** - route for Mayan’s original Wormhole transfer protocol
 
-In addition to these routes, developers can create custom routes for their own Wormhole-based protocols. For examples, refer to the [NTT](https://github.com/wormhole-foundation/example-native-token-transfers/tree/main/sdk/route){target=\_blank} and the [Mayan](https://github.com/mayan-finance/wormhole-sdk-route){target=\_blank} example GitHub repositories.
+In addition to these routes, developers can create custom routes for their own Wormhole-based protocols. For examples, refer to the [NTT](https://github.com/wormhole-foundation/native-token-transfers/tree/main/sdk/route){target=\_blank} and the [Mayan](https://github.com/mayan-finance/wormhole-sdk-route){target=\_blank} example GitHub repositories.
 
 For further details on the Route plugin interface, refer to the [Wormhole TypeScript SDK route code](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/route.ts){target=\_blank}.
 

--- a/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-evm.md
+++ b/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-evm.md
@@ -14,7 +14,7 @@ Tokens integrated with `NttManager` in `burning` mode require the following two 
 - `burn(uint256 amount)`
 - `mint(address account, uint256 amount)`
 
-These functions aren't part of the standard ERC-20 interface. The [`INttToken` interface](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} documents the required functions and convenience methods, errors, and events.
+These functions aren't part of the standard ERC-20 interface. The [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} documents the required functions and convenience methods, errors, and events.
 
 ??? code "View the complete `INttToken` Interface`"
     ```solidity
@@ -103,7 +103,7 @@ The final step in the deployment process is to set the NTT Manager as a minter o
 !!! note
     The required NTT Manager address can be found in the `deployment.json` file.
 
-- If you followed the [`INttToken`](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} interface, you can execute the `setMinter(address newMinter)` function
+- If you followed the [`INttToken`](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} interface, you can execute the `setMinter(address newMinter)` function
     ```json
     cast send $TOKEN_ADDRESS "setMinter(address)" $NTT_MANAGER_ADDRESS --private-key $ETH_PRIVATE_KEY --rpc-url $YOUR_RPC_URL  
     ```

--- a/build/contract-integrations/native-token-transfers/deployment-process/installation.md
+++ b/build/contract-integrations/native-token-transfers/deployment-process/installation.md
@@ -15,7 +15,7 @@ The fastest way to deploy Native Token Transfers (NTT) is using the NTT CLI. As 
 Install the NTT CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wormhole-foundation/example-native-token-transfers/main/cli/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/cli/install.sh | bash
 ```
 
 Verify the NTT CLI is installed:

--- a/build/contract-integrations/native-token-transfers/faqs.md
+++ b/build/contract-integrations/native-token-transfers/faqs.md
@@ -25,7 +25,7 @@ By importing this package, the Wormhole SDK can register and utilize the require
 
 ## How can I transfer ownership of NTT to a multisig?
 
-Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin.rs#L16-L60){target=\_blank} to initiate the transfer.
+Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin.rs#L16-L60){target=\_blank} to initiate the transfer.
 
 1. **Initiate transfer** - use the `transfer_ownership` method on the NTT Manager contract to set the new owner (the multisig)
 2. **Claim ownership** - the multisig must then claim ownership via the `claim_ownership` instruction. If not claimed, the current owner can cancel the transfer
@@ -75,7 +75,7 @@ Yes, the NTT manager acts like an escrow account for non-transferable tokens on 
 
 ## Which functions or events does Connect rely on for NTT integration?
 
-Connect relies on the NTT SDK for integration, with platform-specific implementations for both [Solana](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/solana/ts/sdk/ntt.ts){target=\_blank} and [EVM](https://github.com/wormhole-foundation/example-native-token-transfers/blob/main/evm/ts/src/ntt.ts){target=\_blank}. The key methods involved include:
+Connect relies on the NTT SDK for integration, with platform-specific implementations for both [Solana](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/ts/sdk/ntt.ts){target=\_blank} and [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/ts/src/ntt.ts){target=\_blank}. The key methods involved include:
 
 - **Initiate and redeem functions** - these functions are essential for initiating token transfers and redeeming them on the destination chain
 - **Rate capacity methods** - methods for fetching inbound and outbound rate limits are also critical for controlling the flow of tokens and preventing congestion


### PR DESCRIPTION
### Description

wormhole wants to rename the repo example-native-token-transfers to native-token-transfers so dropping the example-
this pr updates the links that point to that repo

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
