### PR TITLE
add wormhole-sdk custom routes section

### DIFF
--- a/.snippets/code/build/applications/wormhole-sdk/custom-route.ts
+++ b/.snippets/code/build/applications/wormhole-sdk/custom-route.ts
@@ -1,0 +1,11 @@
+import { Network, routes } from '@wormhole-foundation/sdk-connect';
+
+export class CustomRoute<N extends Network>
+  extends routes.Route<N>
+  implements routes.StaticRouteMethods<typeof CustomRoute>
+{
+  static meta = {
+    name: 'CustomRoute',
+  };
+  // implementation...
+}

--- a/build/applications/wormhole-sdk.md
+++ b/build/applications/wormhole-sdk.md
@@ -384,7 +384,7 @@ See the `router.ts` example in the [examples directory](https://github.com/wormh
 
 ### Routes as Plugins
 
-Routes can be imported from any npm package that exports them and configured with the resolver. Custom routes must extend [Route](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L21-L64) and implement [StaticRouteMethods](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L101).
+Routes can be imported from any npm package that exports them and configured with the resolver. Custom routes must extend [`Route`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L21-L64){target=\_blank} and implement [`StaticRouteMethods`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L101){target=\_blank}.
 
 ```ts
 --8 <--"code/build/applications/wormhole-sdk/custom-route.ts";

--- a/build/applications/wormhole-sdk.md
+++ b/build/applications/wormhole-sdk.md
@@ -390,7 +390,7 @@ Routes can be imported from any npm package that exports them and configured wit
 --8 <--"code/build/applications/wormhole-sdk/custom-route.ts";
 ```
 
-A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the `NttAutomaticRoute` implementation [here](https://github.com/wormhole-foundation/native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48).
+A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the [`NttAutomaticRoute` implementation](https://github.com/wormhole-foundation/native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48){target=\_blank}.
 
 ## See Also
 

--- a/build/applications/wormhole-sdk.md
+++ b/build/applications/wormhole-sdk.md
@@ -390,7 +390,7 @@ Routes can be imported from any npm package that exports them and configured wit
 --8 <--"code/build/applications/wormhole-sdk/custom-route.ts";
 ```
 
-A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the [`NttAutomaticRoute` implementation](https://github.com/wormhole-foundation/native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48){target=\_blank}.
+A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the [`NttAutomaticRoute`](https://github.com/wormhole-foundation/native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48){target=\_blank} route implementation.
 
 ## See Also
 

--- a/build/applications/wormhole-sdk.md
+++ b/build/applications/wormhole-sdk.md
@@ -390,7 +390,7 @@ Routes can be imported from any npm package that exports them and configured wit
 --8 <--"code/build/applications/wormhole-sdk/custom-route.ts";
 ```
 
-A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the `NttAutomaticRoute` implementation [here](https://github.com/wormhole-foundation/example-native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48).
+A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the `NttAutomaticRoute` implementation [here](https://github.com/wormhole-foundation/native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48).
 
 ## See Also
 

--- a/build/applications/wormhole-sdk.md
+++ b/build/applications/wormhole-sdk.md
@@ -382,6 +382,16 @@ Finally, assuming the quote looks good, the route can initiate the request with 
 
 See the `router.ts` example in the [examples directory](https://github.com/wormhole-foundation/wormhole-sdk-ts/tree/main/examples){target=\_blank} for a full working example.
 
+### Routes as Plugins
+
+Routes can be imported from any npm package that exports them and configured with the resolver. Custom routes must extend [Route](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L21-L64) and implement [StaticRouteMethods](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/0c57292368146c460abc9ce9e7f6a42be8e0b903/connect/src/routes/route.ts#L101).
+
+```ts
+--8 <--"code/build/applications/wormhole-sdk/custom-route.ts";
+```
+
+A noteworthy example of a route exported from a separate npm package is Wormhole Native Token Transfers (NTT). See the `NttAutomaticRoute` implementation [here](https://github.com/wormhole-foundation/example-native-token-transfers/blob/66f8e414223a77f5c736541db0a7a85396cab71c/sdk/route/src/automatic.ts#L48).
+
 ## See Also
 
 The TSdoc is available [on GitHub](https://wormhole-foundation.github.io/wormhole-sdk-ts/){target=\_blank}.


### PR DESCRIPTION
### Description

This adds a Routes as Plugins (custom routes) section to the TypeScript SDK docs. It also points to the NTT SDK as an example.

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
