### PR TITLE
removed gateway from docs

### DIFF
--- a/.snippets/text/build/start-building/supported-networks/cosmos/IBCRelayerAllowlistTemplate.md
+++ b/.snippets/text/build/start-building/supported-networks/cosmos/IBCRelayerAllowlistTemplate.md
@@ -1,9 +1,0 @@
-Hey @Guardians! Thank you for passing governance to support **[Cosmos Chain]** via Wormhole Gateway. We are very excited to integrate with Wormhole!
-
-We will be using **[Relayer Provider]** as our IBC relayer to support the connection to Wormhole Gateway. Their address is **[Wormhole Gateway address].** 
-
-Could one of the Guardians please allowlist this address so that it can submit transactions to Wormhole Gateway?
-
-We understand that if this address misbehaves, the sponsoring Guardian can remove it from the allowlist at any time, which would effectively shut down IBC bridging to/from our chain and Gateway.
-
-Thank you!

--- a/build/contract-integrations/faqs.md
+++ b/build/contract-integrations/faqs.md
@@ -16,9 +16,9 @@ The logic behind deploying these token contracts involves submitting an attestat
 
 Relevant contracts:
 
- - [Ethereum ERC-20](https://github.com/wormhole-foundation/wormhole/blob/gateway-integration/ethereum/contracts/bridge/token/Token.sol){target=\_blank}
- - [Solana SPL](https://github.com/wormhole-foundation/wormhole/blob/gateway-integration/solana/modules/token_bridge/program/src/api/create_wrapped.rs#L128-L145){target=\_blank}
- - [Attestation VAA and Token Contract Deployment Logic](https://github.com/wormhole-foundation/wormhole/blob/gateway-integration/ethereum/contracts/bridge/Bridge.sol#L385-L431){target=\_blank}
+ - [Ethereum ERC-20](https://github.com/wormhole-foundation/wormhole/blob/main/ethereum/contracts/bridge/token/Token.sol){target=\_blank}
+ - [Solana SPL](https://github.com/wormhole-foundation/wormhole/blob/main/solana/modules/token_bridge/program/src/api/create_wrapped.rs#L128-L145){target=\_blank}
+ - [Attestation VAA and Token Contract Deployment Logic](https://github.com/wormhole-foundation/wormhole/blob/main/ethereum/contracts/bridge/Bridge.sol#L385-L431){target=\_blank}
 
 ## How do I start developing a custom relayer?
 


### PR DESCRIPTION
### Description

Removed all gateway information left from docs.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
