### PR TITLE
removed old terms from glossary

### DIFF
--- a/learn/fundamentals/glossary.md
+++ b/learn/fundamentals/glossary.md
@@ -70,19 +70,3 @@ A Spy is a daemon that eavesdrops on the messages passed between Guardians, typi
 ## Validator
 
 A daemon configured to monitor a blockchain node and observe messages emitted by the Wormhole contracts.
-
-## xChain
-
-A term that refers to the full range of cross-blockchain interoperability.
-
-## xAssets
-
-A chain-and-path agnostic token on a layer outside the blockchain ecosystem that can conduct transactions on any blockchain.
-
-## xDapp
-
-A decentralized application that enables users to create and/or use [xData](#xdata).
-
-## xData
-
-Data that exists in a layer outside of Layer 1 blockchains, which is accessible by all chains.


### PR DESCRIPTION
### Description

Removed old terms from the glossary.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
