### PR TITLE
updated title to multigov

### DIFF
--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -20,7 +20,7 @@ This section contains step-by-step tutorials to help you build with Wormhole.
 
     [:octicons-arrow-right-16: Start building](/docs/tutorials/messaging/)
 
--   :octicons-checklist-16:{ .lg .middle } **MultiGov**
+-   :octicons-law-16:{ .lg .middle } **MultiGov**
 
     ---
 

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -20,7 +20,7 @@ This section contains step-by-step tutorials to help you build with Wormhole.
 
     [:octicons-arrow-right-16: Start building](/docs/tutorials/messaging/)
 
--   :octicons-checklist-16:{ .lg .middle } **Messaging**
+-   :octicons-checklist-16:{ .lg .middle } **MultiGov**
 
     ---
 


### PR DESCRIPTION
### Description

Updated duplicate title in the Tutorial's index page.

<img width="713" alt="index-tutorials" src="https://github.com/user-attachments/assets/224714c8-4bf1-44b0-afa3-dfb1a300a942">

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
