### PR TITLE
add link to demo on github for tutorial

### DIFF
--- a/tutorials/by-product/contract-integrations/cross-chain-contracts.md
+++ b/tutorials/by-product/contract-integrations/cross-chain-contracts.md
@@ -5,6 +5,8 @@ description: Learn how to create cross-chain contracts using Wormhole's Solidity
 
 # Create Cross-Chain Messaging Contracts
 
+:simple-github: [Source code on GitHub](https://github.com/wormhole-foundation/demo-wormhole-messaging){target=\_blank}
+
 ## Introduction
 
 Wormhole's cross-chain messaging allows smart contracts to interact seamlessly across multiple blockchains. This enables developers to build decentralized applications that leverage the strengths of different networks, whether it's Avalanche, Celo, Ethereum, or beyond. In this tutorial, we'll explore using [Wormhole's Solidity SDK](https://github.com/wormhole-foundation/wormhole-solidity-sdk){target=\_blank} to create cross-chain contracts to send and receive messages across chains.


### PR DESCRIPTION
### Description

Added missing link to GitHub for the messaging tutorial.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
