### PR TITLE
fix link

### DIFF
--- a/build/start-building/index.md
+++ b/build/start-building/index.md
@@ -27,7 +27,7 @@ Wormhole's role as a Generic Message Passing (GMP) protocol means it facilitates
 
     Leverage Wormhole's powerful messaging protocols to create contracts that can communicate and interact across multiple blockchains. By using Wormhole’s core infrastructure, you can enable secure and seamless messaging, asset transfers, and more between supported networks.
 
-    [:octicons-arrow-right-16: Integrate with contracts](/docs/build/applications/connect/)
+    [:octicons-arrow-right-16: Integrate with contracts](/docs/build/contract-integrations/)
 
 </div>
 


### PR DESCRIPTION
### Description

fixed wrong link for start building > contract integrations

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
