### PR TITLE
added links to ntt post deployment

### DIFF
--- a/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-evm.md
+++ b/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-evm.md
@@ -138,3 +138,6 @@ The final step in the deployment process is to set the NTT Manager as a minter o
 - If you have a custom process to manage token minters, you should now follow that process to add the corresponding NTT Manager as a minter
 
 By default, NTT transfers to EVM blockchains support automatic relaying via the Wormhole relayer, which doesn't require the user to perform a transaction on the destination chain to complete the transfer.
+
+!!!important
+    To proceed with testing and find integration examples, check out the [NTT Post Deployment](/docs/build/contract-integrations/native-token-transfers/deployment-process/post-deployment/){target=\_blank} page.

--- a/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-solana.md
+++ b/build/contract-integrations/native-token-transfers/deployment-process/deploy-to-solana.md
@@ -177,3 +177,6 @@ ntt push --payer INSERT_YOUR_KEYPAIR_JSON
 ```
 
 By default, NTT transfers to Solana support manual relaying, which requires the user to perform a transaction on Solana to complete the transfer. UI components such as Wormhole Connect support this out of the box. For automatic Wormhole relaying support on Solana, [contact](https://forms.clickup.com/45049775/f/1aytxf-10244/JKYWRUQ70AUI99F32Q){target=\_blank} Wormhole contributors.
+
+!!!important
+    To proceed with testing and find integration examples, check out the [NTT Post Deployment](/docs/build/contract-integrations/native-token-transfers/deployment-process/post-deployment/){target=\_blank} page.


### PR DESCRIPTION
### Description

Added at the end of Native Token Transfers EVM Deployment for evm and solana sections a short sentence with a link to "Post Deployment"

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
