### PR TITLE
add cctp index card

### DIFF
--- a/build/contract-integrations/index.md
+++ b/build/contract-integrations/index.md
@@ -27,6 +27,14 @@ The content in this section will teach you how to create smart contracts that in
 
     [:octicons-arrow-right-16: Get started with Core Contracts](/docs/build/contract-integrations/core-contracts/)
 
+-   :octicons-code-square-16:{ .lg .middle } **CCTP**
+
+    ---
+
+    Learn how to interact directly with Circle's CCTP Bridge contracts, including TokenMessenger, TokenMinter, and MessageTransmitter. 
+
+    [:octicons-arrow-right-16: Get started with CCTP](/docs/build/contract-integrations/cctp/)
+
 -   :octicons-sync-16:{ .lg .middle } **Native Token Transfers**
 
     ---

--- a/build/contract-integrations/index.md
+++ b/build/contract-integrations/index.md
@@ -31,7 +31,7 @@ The content in this section will teach you how to create smart contracts that in
 
     ---
 
-    Learn how to interact directly with Circle's CCTP Bridge contracts, including TokenMessenger, TokenMinter, and MessageTransmitter. 
+    Learn how to interact directly with Circle's CCTP Bridge contracts, including Token Messenger, Token Minter, and Message Transmitter. 
 
     [:octicons-arrow-right-16: Get started with CCTP](/docs/build/contract-integrations/cctp/)
 


### PR DESCRIPTION
### Description

Added cctp index card which was missing in the build > contract integrations index page 

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
