### PR TITLE
Updates build/index page as part of SDK reorg

### DIFF
--- a/build/index.md
+++ b/build/index.md
@@ -8,7 +8,7 @@ template: root-index-page.html
 
 ## Get Started
 
-Whether you’re developing front-end applications using Wormhole's application-layer tools or building smart contract integrations on top of Wormhole’s messaging protocols, learn how Wormhole can help you achieve seamless, multichain interoperability.
+Whether you're developing front-end applications using Wormhole's application-layer tools or building smart contract integrations on top of Wormhole's messaging protocols, learn how Wormhole can help you achieve seamless, multichain interoperability.
 
 <div class="grid cards" markdown>
 
@@ -20,7 +20,15 @@ Whether you’re developing front-end applications using Wormhole's application-
 
     [:octicons-arrow-right-16: Get started](/docs/build/start-building/)
 
--   :octicons-browser-16:{ .lg .middle } **Build Frontend Applications**
+</div>
+
+## Guidance by Project Type
+
+Use the following links to quickly access guides based on what you want to build today.
+
+<div class="grid cards" markdown>
+
+- :octicons-browser-16:{ .lg .middle } **Frontend Applications**
 
     ---
 
@@ -28,13 +36,59 @@ Whether you’re developing front-end applications using Wormhole's application-
 
     [:octicons-arrow-right-16: Build applications](/docs/build/applications/)
 
--   :octicons-file-code-16:{ .lg .middle } **Build Contract Integrations**
+- :octicons-file-code-16:{ .lg .middle } **Smart Contracts**
 
     ---
 
     Begin your journey by creating smart contracts that harness the power of Wormhole's advanced messaging protocols.
 
-    [:octicons-arrow-right-16: Build contract integrations](/docs/build/contract-integrations/)
+    [:octicons-arrow-right-16: Build smart contracts](/docs/build/contract-integrations/)
+
+- :octicons-tools-16:{ .lg .middle } **Data Analysis Tools**
+
+    --- 
+
+    Use Wormhole Queries to power your data dashboards and analytics tooling by providing on-demand access to Guardian-attested on-chain data via a simple REST endpoint.
+
+    [:octicons-arrow-right-16: Investigate Queries](/docs/build/applications/queries/)
+
+- :octicons-link-16:{ .lg .middle } **Cross-Chain Messaging**
+
+    ---
+
+    Leverage Wormhole-deployed relayers to allow contracts to send messages to each other across chains without requiring off-chain infrastructure.
+
+    [:octicons-arrow-right-16: Explore relayers](/docs/build/contract-integrations/wormhole-relayers/)
+
+- :octicons-link-16:{ .lg .middle } **Cross-Chain USDC Transfers**
+
+    ---
+
+    Discover Wormhole's Cross-Chain Transfer Protocol (CCTP) contracts to facilitate secure and efficient USDC transfers across blockchain networks with native burning and minting mechanisms.
+
+    [:octicons-arrow-right-16: Use Wormhole CCTP](/docs/build/contract-integrations/cctp/)
+
+- :octicons-code-of-conduct-16:{ .lg .middle } **Multichain Governance**
+
+    ---
+
+    Learn how to use Wormhole's MultiGov cross-chain governance mechanisms to create, vote on, and execute community proposals.
+
+    [:octicons-arrow-right-16: Build with MultiGov](/docs/build/contract-integrations/multigov/)
+
+- :octicons-globe-16:{ .lg .middle } **Multichain Native Tokens**
+
+    ---
+
+    Comprehensive guidance on using Wormhole's Native Token Transfer (NTT) to configure, deploy, and manage your multichain native token.
+
+    [:octicons-arrow-right-16: Discover Native Token Transfers](/docs/build/contract-integrations/native-token-transfers/)
+
+</div>
+
+## Additional Resources
+
+<div class="grid cards" markdown>
 
 -   :octicons-gear-16:{ .lg .middle } **Toolkit**
 
@@ -48,7 +102,7 @@ Whether you’re developing front-end applications using Wormhole's application-
 
     ---
 
-    Find essential reference information for development, including canonical contract addresses, Wormhole chain IDs, and consistency levels for Guardians.
+    Here, you can find essential reference information for development, including canonical contract addresses, Wormhole chain IDs, and consistency levels for Guardians.
 
     [:octicons-arrow-right-16: Explore reference](/docs/build/reference/)
 


### PR DESCRIPTION
### Description

This PR updates the Build/index page to feature links to information by project type. Separate PRs and tickets will update the other related pages. 

### Checklist

- [ x] **Required** - I have added a label to this PR 🏷️
- [ x] **Required** - I have run my changes through Grammarly
- N/A If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
