### PR TITLE
Replace NTT card with Multichain Assets on the Tutorials by Product index page

### DIFF
--- a/tutorials/by-product/index.md
+++ b/tutorials/by-product/index.md
@@ -47,6 +47,6 @@ In this section, you'll find tutorials focused on individual Wormhole products. 
 
     Learn how to create, register, and manage wrapped multichain assets across multiple chains. These tutorials will guide you through the process of enabling asset transfers between supported networks.
 
-    [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/multichain-assets/multichain-token/)
+    [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/multichain-assets/)
 
 </div>

--- a/tutorials/by-product/index.md
+++ b/tutorials/by-product/index.md
@@ -25,14 +25,6 @@ In this section, you'll find tutorials focused on individual Wormhole products. 
 
     [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/contract-integrations/)
 
--   :octicons-sync-16:{ .lg .middle } **Native Token Transfers**
-
-    ---
-
-    Discover how to move native assets across different chains. These tutorials will help you set up and execute cross-chain token transfers, ensuring secure, efficient, and scalable bridging solutions for your users and applications.
-
-    [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/native-token-transfers/)
-
 -   :octicons-people-16:{ .lg .middle } **MultiGov**
 
     ---
@@ -48,5 +40,13 @@ In this section, you'll find tutorials focused on individual Wormhole products. 
     Master the tools to build cross-chain applications with the Wormhole SDK. These tutorials cover installation to advanced functionality, helping you streamline development, reduce complexity, and quickly bring your ideas to life. 
 
     [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/wormhole-sdk/)
+
+-   :octicons-sync-16:{ .lg .middle } **Multichain Assets**
+
+    ---
+
+    Learn how to create, register, and manage wrapped multichain assets across multiple chains. These tutorials will guide you through the process of enabling asset transfers between supported networks.
+
+    [:octicons-arrow-right-16: Start building](/docs/tutorials/by-product/multichain-assets/multichain-token/)
 
 </div>


### PR DESCRIPTION
### Description

We removed the NTT section temporarily because we don't have any NTT tutorials quite yet. The tutorial that was under NTT was actually for wrapped assets, so that was moved to the Multichain Assets section. So this PR updates the Tutorials by Product index page to reflect these changes

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
