### PR TITLE
Semrush Audit February

### DIFF
--- a/build/applications/queries/use-queries.md
+++ b/build/applications/queries/use-queries.md
@@ -143,7 +143,7 @@ A Mainnet Query Proxy is available at `https://query.wormhole.com/v1/query`
 
 ## Verify a Query Response On-Chain
 
-A [`QueryResponse` abstract contract](https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/QueryResponse.sol){target=\_blank} is provided to assist with verifying query responses. You can begin by installing the [Wormhole Solidity SDK](https://github.com/wormhole-foundation/wormhole-solidity-sdk){target=\_blank} with the following command:
+A [`QueryResponseLib` library](https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/libraries/QueryResponse.sol){target=\_blank} is provided to assist with verifying query responses. You can begin by installing the [Wormhole Solidity SDK](https://github.com/wormhole-foundation/wormhole-solidity-sdk){target=\_blank} with the following command:
 
 ```bash
 forge install wormhole-foundation/wormhole-solidity-sdk

--- a/learn/messaging/cctp.md
+++ b/learn/messaging/cctp.md
@@ -20,7 +20,7 @@ You can use Wormhole's CCTP-powered USDC bridging by embedding the [Connect Widg
 
 ## Automatic Relaying
 
-To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/stablecoins/reference/getattestation){target=\_blank} must be delivered to the destination chain.
+To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/api-reference/stablecoins/common/get-attestation){target=\_blank} must be delivered to the destination chain.
 
 This attestation delivery may be difficult or impossible in some contexts. For example, in a browser context, the user doesn't wish to wait for finality to deliver the attestation. To address this difficulty, the Wormhole CCTP relayer may be used either with the [Wormhole Connect Widget](/docs/build/applications/connect/overview/){target=\_blank} or more directly with the [Wormhole TypeScript SDK](/docs/build/applications/wormhole-sdk/){target=\_blank}.
 

--- a/llms.txt
+++ b/llms.txt
@@ -2889,7 +2889,7 @@ A Mainnet Query Proxy is available at `https://query.wormhole.com/v1/query`
 
 ## Verify a Query Response On-Chain
 
-A [`QueryResponse` abstract contract](https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/QueryResponse.sol){target=\_blank} is provided to assist with verifying query responses. You can begin by installing the [Wormhole Solidity SDK](https://github.com/wormhole-foundation/wormhole-solidity-sdk){target=\_blank} with the following command:
+A [`QueryResponseLib` library](https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/libraries/QueryResponse.sol){target=\_blank} is provided to assist with verifying query responses. You can begin by installing the [Wormhole Solidity SDK](https://github.com/wormhole-foundation/wormhole-solidity-sdk){target=\_blank} with the following command:
 
 ```bash
 forge install wormhole-foundation/wormhole-solidity-sdk
@@ -14896,7 +14896,7 @@ You can use Wormhole's CCTP-powered USDC bridging by embedding the [Connect Widg
 
 ## Automatic Relaying
 
-To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/stablecoins/reference/getattestation){target=\_blank} must be delivered to the destination chain.
+To complete a CCTP transfer, the [Circle Attestation](https://developers.circle.com/api-reference/stablecoins/common/get-attestation){target=\_blank} must be delivered to the destination chain.
 
 This attestation delivery may be difficult or impossible in some contexts. For example, in a browser context, the user doesn't wish to wait for finality to deliver the attestation. To address this difficulty, the Wormhole CCTP relayer may be used either with the [Wormhole Connect Widget](/docs/build/applications/connect/overview/){target=\_blank} or more directly with the [Wormhole TypeScript SDK](/docs/build/applications/wormhole-sdk/){target=\_blank}.
 


### PR DESCRIPTION
### Description

This audit was smaller than last month's; it addresses only two broken links and a minor word change from 'smart contract' to 'library.'

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
