### PR TITLE
Update index page icons for consistency

### DIFF
--- a/build/reference/index.md
+++ b/build/reference/index.md
@@ -19,7 +19,7 @@ In this section, you'll find reference information that is essential for develop
 
     [:custom-arrow: View list of chain IDs](/docs/build/reference/chain-ids/)
 
--   :material-timer-sand:{ .lg .middle } **Consistency Levels**
+-   :octicons-clock-16:{ .lg .middle } **Consistency Levels**
 
     ---
 
@@ -43,11 +43,11 @@ In this section, you'll find reference information that is essential for develop
 
     [:custom-arrow: View list of contract addresses](/docs/build/reference/contract-addresses/)
 
--   :material-code-braces:{ .lg .middle } **Wormhole Formatted Addresses**
+-   :octicons-checkbox-16:{ .lg .middle } **Wormhole Formatted Addresses**
 
     ---
 
-    Learn how Wormhole formats addresses into a 32-byte hex format for cross-chain compatibility. 
+    Learn how Wormhole formats addresses into a 32-byte hex format for cross-chain compatibility.
     
     This includes converting addresses between their native formats and the Wormhole format across multiple blockchains.
 

--- a/infrastructure/relayers/index.md
+++ b/infrastructure/relayers/index.md
@@ -48,7 +48,7 @@ description: Learn how to develop your own custom off-chain relaying service, gi
 
     [:custom-arrow: Learn more about relayers](/docs/learn/infrastructure/relayer/)
 
--   :material-package-variant:{ .lg .middle } **Simplify the Development Process**
+-   :octicons-gear-16:{ .lg .middle } **Simplify the Development Process**
 
     ---
 

--- a/infrastructure/spy/index.md
+++ b/infrastructure/spy/index.md
@@ -31,7 +31,7 @@ description: Discover everything you need to about the Wormhole Spy, a daemon th
 
     [:custom-arrow: Learn more about Spies](/docs/learn/infrastructure/spy/)
 
--   :material-package-variant:{ .lg .middle } **Interact with a Spy**
+-   :octicons-code-16:{ .lg .middle } **Interact with a Spy**
 
     ---
 
@@ -39,7 +39,7 @@ description: Discover everything you need to about the Wormhole Spy, a daemon th
 
     [:custom-arrow: Use the Wormhole Spy SDK](https://github.com/wormhole-foundation/wormhole/blob/main/spydk/js/README.md){target=\_blank}
 
--   :material-package-variant:{ .lg .middle } **Alternative Implementations**
+-   :octicons-bookmark-16:{ .lg .middle } **Alternative Implementations**
 
     ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -10951,7 +10951,7 @@ In this section, you'll find reference information that is essential for develop
 
     [:custom-arrow: View list of chain IDs](/docs/build/reference/chain-ids/)
 
--   :material-timer-sand:{ .lg .middle } **Consistency Levels**
+-   :octicons-clock-16:{ .lg .middle } **Consistency Levels**
 
     ---
 
@@ -10975,11 +10975,11 @@ In this section, you'll find reference information that is essential for develop
 
     [:custom-arrow: View list of contract addresses](/docs/build/reference/contract-addresses/)
 
--   :material-code-braces:{ .lg .middle } **Wormhole Formatted Addresses**
+-   :octicons-checkbox-16:{ .lg .middle } **Wormhole Formatted Addresses**
 
     ---
 
-    Learn how Wormhole formats addresses into a 32-byte hex format for cross-chain compatibility. 
+    Learn how Wormhole formats addresses into a 32-byte hex format for cross-chain compatibility.
     
     This includes converting addresses between their native formats and the Wormhole format across multiple blockchains.
 
@@ -13047,7 +13047,7 @@ description: Learn how to develop your own custom off-chain relaying service, gi
 
     [:custom-arrow: Learn more about relayers](/docs/learn/infrastructure/relayer/)
 
--   :material-package-variant:{ .lg .middle } **Simplify the Development Process**
+-   :octicons-gear-16:{ .lg .middle } **Simplify the Development Process**
 
     ---
 
@@ -13413,7 +13413,7 @@ description: Discover everything you need to about the Wormhole Spy, a daemon th
 
     [:custom-arrow: Learn more about Spies](/docs/learn/infrastructure/spy/)
 
--   :material-package-variant:{ .lg .middle } **Interact with a Spy**
+-   :octicons-code-16:{ .lg .middle } **Interact with a Spy**
 
     ---
 
@@ -13421,7 +13421,7 @@ description: Discover everything you need to about the Wormhole Spy, a daemon th
 
     [:custom-arrow: Use the Wormhole Spy SDK](https://github.com/wormhole-foundation/wormhole/blob/main/spydk/js/README.md){target=\_blank}
 
--   :material-package-variant:{ .lg .middle } **Alternative Implementations**
+-   :octicons-bookmark-16:{ .lg .middle } **Alternative Implementations**
 
     ---
 


### PR DESCRIPTION
### Description

This PR just converts the few remaining material icons on the index pages to octicons, so they have the same properties across the board. For example, material applies a different viewbox size to their icons and octicons doesn't

This kinda goes with this mkdocs PR: https://github.com/papermoonio/wormhole-mkdocs/pull/156

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
