### PR TITLE
Semrush march fix

### DIFF
--- a/build/transfers/connect/configuration-v0.md
+++ b/build/transfers/connect/configuration-v0.md
@@ -1,5 +1,5 @@
 ---
-title: Configure Your Connect Widget: v0
+title: Configure Your Connect Widget v0
 description: Configure Wormhole Connect v0 for React or HTML, set themes, define tokens, networks, and customize RPC endpoints for optimized blockchain interactions.
 ---
 

--- a/build/transfers/native-token-transfers/faqs.md
+++ b/build/transfers/native-token-transfers/faqs.md
@@ -25,7 +25,7 @@ By importing this package, the Wormhole SDK can register and utilize the require
 
 ## How can I transfer ownership of NTT to a multisig?
 
-Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin.rs#L16-L60){target=\_blank} to initiate the transfer.
+Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs#L55){target=\_blank} to initiate the transfer.
 
 1. **Initiate transfer** - use the `transfer_ownership` method on the NTT Manager contract to set the new owner (the multisig)
 2. **Claim ownership** - the multisig must then claim ownership via the `claim_ownership` instruction. If not claimed, the current owner can cancel the transfer

--- a/llms.txt
+++ b/llms.txt
@@ -9566,7 +9566,7 @@ To view a complete example of creating a contract that integrates with Wormhole'
 Doc-Content: https://wormhole.com/docs/build/transfers/connect/configuration-v0/
 --- BEGIN CONTENT ---
 ---
-title: Configure Your Connect Widget: v0
+title: Configure Your Connect Widget v0
 description: Configure Wormhole Connect v0 for React or HTML, set themes, define tokens, networks, and customize RPC endpoints for optimized blockchain interactions.
 ---
 
@@ -13017,7 +13017,7 @@ By importing this package, the Wormhole SDK can register and utilize the require
 
 ## How can I transfer ownership of NTT to a multisig?
 
-Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin.rs#L16-L60){target=\_blank} to initiate the transfer.
+Transferring ownership of Wormhole's NTT to a multisig is a two-step process for safety. This ensures that ownership is not transferred to an address that cannot claim it. Refer to the `transfer_ownership` method in the [NTT Manager Contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/example-native-token-transfers/src/instructions/admin/transfer_ownership.rs#L55){target=\_blank} to initiate the transfer.
 
 1. **Initiate transfer** - use the `transfer_ownership` method on the NTT Manager contract to set the new owner (the multisig)
 2. **Claim ownership** - the multisig must then claim ownership via the `claim_ownership` instruction. If not claimed, the current owner can cancel the transfer


### PR DESCRIPTION
### Description
I created a new pull request for the March Semrush report because the previous one had too many merge conflicts. 
https://github.com/wormhole-foundation/wormhole-docs/pull/296

**this is the original description (addresses the same issues)**
I updated a GitHub link and removed the colon from a title because it created a conflict that prevented the description from appearing, resulting in an error in the SEMrush report.

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
