### PR TITLE
refresh infra architecture, updates llms

### DIFF
--- a/learn/infrastructure/architecture.md
+++ b/learn/infrastructure/architecture.md
@@ -52,12 +52,12 @@ The preceding diagram outlines the end-to-end flow of multichain communication t
 
     [:custom-arrow: Explore Core Contracts](/docs/learn/infrastructure/core-contracts/)
 
--   :octicons-book-16:{ .lg .middle } **Off-chain Infrastructure**
+-   :octicons-tools-16:{ .lg .middle } **Core Messaging**
 
     ---
 
-    Follow the guides in this section to learn how to run off-chain infrastructure services, such as running a spy or a customized relayer.
+    Follow the guides in this section to work directly with the building blocks of Wormhole messaging, Wormhole-deployed relayers and Core Contracts, to send, receive, validate, and track multichain messages.
 
-    [:custom-arrow: Get Started with Infrastructure](/docs/infrastructure/)
+    [:custom-arrow: Build with Core Messaging](/docs/build/core-messaging/)
 
 </div>

--- a/learn/infrastructure/architecture.md
+++ b/learn/infrastructure/architecture.md
@@ -3,28 +3,30 @@ title: Architecture
 description: Overview of Wormhole's architecture, detailing key on-chain and off-chain components like the Core Contract, Guardian Network, and relayers.
 ---
 
-# Architecture Overview
+# Architecture
 
-## Architecture
+## Overview
 
 Wormhole has several noteworthy components. Before discussing each component in depth, this page will provide an overview of how the major pieces fit together.
 
 ![Wormhole architecture detailed diagram: source to target chain communication.](/docs/images/learn/infrastructure/architecture/architecture-1.webp)
 
-The diagram outlines the end-to-end flow of cross-chain communication through Wormhole's architecture:
+The preceding diagram outlines the end-to-end flow of multichain communication through Wormhole's architecture, which is described as follows:
 
 1. **Source chain** - a source contract emits a message by interacting with the [Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank} on the source chain, which publishes the message in the blockchain's transaction logs
 2. **Guardian Network** - [Guardians](/docs/learn/infrastructure/guardians/){target=\_blank} validate these messages and sign them to produce [Verifiable Action Approvals (VAAs)](/docs/learn/infrastructure/vaas/){target=\_blank}
 3. **Relayers** - off-chain relayers or applications fetch the VAA and relay it to the target chain
-4. **Target chain** - on the target chain, the message is consumed by the appropriate contract. This contract interacts with the Wormhole Core Contract to verify the VAA and execute the intended cross-chain operation. The flow from the relayer to the target chain involves an entry point contract, which could vary based on the use case:
+4. **Target chain** - on the target chain, the message is consumed by the appropriate contract. This contract interacts with the Wormhole Core Contract to verify the VAA and execute the intended multichain operation. 
+
+    The flow from the relayer to the target chain involves an entry point contract, which could vary based on the use case:
 
     - In some applications, the target contract acts as the entry point and performs verification via the Core Contract
     - In products like the Token Bridge, the Token Bridge contract itself interacts with the Core Contract
 
 ## On-Chain Components
 
-- **Emitter** - a contract that calls the publish message method on the Core Contract. The Core Contract will write an event to the transaction logs with details about the emitter and sequence number to identify the message. This may be your [xDapp](/docs/learn/glossary/#xdapp){target=\_blank} or an existing ecosystem protocol
-- **[Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank}** - primary contract, this is the contract which the Guardians observe and which fundamentally allows for cross-chain communication
+- **Emitter** - a contract that calls the publish message method on the Core Contract. To identify the message, the Core Contract will write an event to the transaction logs with details about the emitter and sequence number. This may be your [xDapp](/docs/learn/glossary/#xdapp){target=\_blank} or an existing ecosystem protocol
+- **[Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank}** - primary contract, this is the contract which the Guardians observe and which fundamentally allows for multichain communication
 - **Transaction logs** - blockchain-specific logs that allow the Guardians to observe messages emitted by the Core Contract
 
 ## Off-Chain Components
@@ -36,4 +38,26 @@ The diagram outlines the end-to-end flow of cross-chain communication through Wo
 - **[VAAs](/docs/learn/infrastructure/vaas/){target=\_blank}** - Verifiable Action Approvals (VAAs) are the signed attestation of an observed message from the Wormhole Core Contract
 - **[Relayer](/docs/learn/infrastructure/relayer/){target=\_blank}** - any off-chain process that relays a VAA to the target chain
     - **Wormhole relayers** - a decentralized relayer network that delivers messages that are requested on-chain via the Wormhole relayer contract
-    - **Custom relayers** - relayers that only handle VAAs for a specific protocol or cross-chain application. They can execute custom logic off-chain, reducing gas costs and increasing cross-chain compatibility. Currently, cross-chain application developers are responsible for developing and hosting custom relayers
+    - **Custom relayers** - relayers that only handle VAAs for a specific protocol or multichain application. They can execute custom logic off-chain, reducing gas costs and increasing multichain compatibility. Currently, multichain application developers are responsible for developing and hosting custom relayers
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :octicons-book-16:{ .lg .middle } **Core Contracts**
+
+    ---
+
+    Discover Wormhole's Core Contracts, enabling multichain communication with message sending, receiving, and multicast features for efficient synchronization.
+
+    [:custom-arrow: Explore Core Contracts](/docs/learn/infrastructure/core-contracts/)
+
+-   :octicons-book-16:{ .lg .middle } **Off-chain Infrastructure**
+
+    ---
+
+    Follow the guides in this section to learn how to run off-chain infrastructure services, such as running a spy or a customized relayer.
+
+    [:custom-arrow: Get Started with Infrastructure](/docs/infrastructure/)
+
+</div>

--- a/llms.txt
+++ b/llms.txt
@@ -15302,28 +15302,30 @@ title: Architecture
 description: Overview of Wormhole's architecture, detailing key on-chain and off-chain components like the Core Contract, Guardian Network, and relayers.
 ---
 
-# Architecture Overview
+# Architecture
 
-## Architecture
+## Overview
 
 Wormhole has several noteworthy components. Before discussing each component in depth, this page will provide an overview of how the major pieces fit together.
 
 ![Wormhole architecture detailed diagram: source to target chain communication.](/docs/images/learn/infrastructure/architecture/architecture-1.webp)
 
-The diagram outlines the end-to-end flow of cross-chain communication through Wormhole's architecture:
+The preceding diagram outlines the end-to-end flow of multichain communication through Wormhole's architecture, which is described as follows:
 
 1. **Source chain** - a source contract emits a message by interacting with the [Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank} on the source chain, which publishes the message in the blockchain's transaction logs
 2. **Guardian Network** - [Guardians](/docs/learn/infrastructure/guardians/){target=\_blank} validate these messages and sign them to produce [Verifiable Action Approvals (VAAs)](/docs/learn/infrastructure/vaas/){target=\_blank}
 3. **Relayers** - off-chain relayers or applications fetch the VAA and relay it to the target chain
-4. **Target chain** - on the target chain, the message is consumed by the appropriate contract. This contract interacts with the Wormhole Core Contract to verify the VAA and execute the intended cross-chain operation. The flow from the relayer to the target chain involves an entry point contract, which could vary based on the use case:
+4. **Target chain** - on the target chain, the message is consumed by the appropriate contract. This contract interacts with the Wormhole Core Contract to verify the VAA and execute the intended multichain operation. 
+
+    The flow from the relayer to the target chain involves an entry point contract, which could vary based on the use case:
 
     - In some applications, the target contract acts as the entry point and performs verification via the Core Contract
     - In products like the Token Bridge, the Token Bridge contract itself interacts with the Core Contract
 
 ## On-Chain Components
 
-- **Emitter** - a contract that calls the publish message method on the Core Contract. The Core Contract will write an event to the transaction logs with details about the emitter and sequence number to identify the message. This may be your [xDapp](/docs/learn/glossary/#xdapp){target=\_blank} or an existing ecosystem protocol
-- **[Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank}** - primary contract, this is the contract which the Guardians observe and which fundamentally allows for cross-chain communication
+- **Emitter** - a contract that calls the publish message method on the Core Contract. To identify the message, the Core Contract will write an event to the transaction logs with details about the emitter and sequence number. This may be your [xDapp](/docs/learn/glossary/#xdapp){target=\_blank} or an existing ecosystem protocol
+- **[Wormhole Core Contract](/docs/learn/infrastructure/core-contracts/){target=\_blank}** - primary contract, this is the contract which the Guardians observe and which fundamentally allows for multichain communication
 - **Transaction logs** - blockchain-specific logs that allow the Guardians to observe messages emitted by the Core Contract
 
 ## Off-Chain Components
@@ -15335,7 +15337,29 @@ The diagram outlines the end-to-end flow of cross-chain communication through Wo
 - **[VAAs](/docs/learn/infrastructure/vaas/){target=\_blank}** - Verifiable Action Approvals (VAAs) are the signed attestation of an observed message from the Wormhole Core Contract
 - **[Relayer](/docs/learn/infrastructure/relayer/){target=\_blank}** - any off-chain process that relays a VAA to the target chain
     - **Wormhole relayers** - a decentralized relayer network that delivers messages that are requested on-chain via the Wormhole relayer contract
-    - **Custom relayers** - relayers that only handle VAAs for a specific protocol or cross-chain application. They can execute custom logic off-chain, reducing gas costs and increasing cross-chain compatibility. Currently, cross-chain application developers are responsible for developing and hosting custom relayers
+    - **Custom relayers** - relayers that only handle VAAs for a specific protocol or multichain application. They can execute custom logic off-chain, reducing gas costs and increasing multichain compatibility. Currently, multichain application developers are responsible for developing and hosting custom relayers
+
+## Next Steps
+
+<div class="grid cards" markdown>
+
+-   :octicons-book-16:{ .lg .middle } **Core Contracts**
+
+    ---
+
+    Discover Wormhole's Core Contracts, enabling multichain communication with message sending, receiving, and multicast features for efficient synchronization.
+
+    [:custom-arrow: Explore Core Contracts](/docs/learn/infrastructure/core-contracts/)
+
+-   :octicons-book-16:{ .lg .middle } **Off-chain Infrastructure**
+
+    ---
+
+    Follow the guides in this section to learn how to run off-chain infrastructure services, such as running a spy or a customized relayer.
+
+    [:custom-arrow: Get Started with Infrastructure](/docs/infrastructure/)
+
+</div>
 --- END CONTENT ---
 
 Doc-Content: https://wormhole.com/docs/learn/infrastructure/core-contracts/

--- a/llms.txt
+++ b/llms.txt
@@ -15351,13 +15351,13 @@ The preceding diagram outlines the end-to-end flow of multichain communication t
 
     [:custom-arrow: Explore Core Contracts](/docs/learn/infrastructure/core-contracts/)
 
--   :octicons-book-16:{ .lg .middle } **Off-chain Infrastructure**
+-   :octicons-tools-16:{ .lg .middle } **Core Messaging**
 
     ---
 
-    Follow the guides in this section to learn how to run off-chain infrastructure services, such as running a spy or a customized relayer.
+    Follow the guides in this section to work directly with the building blocks of Wormhole messaging, Wormhole-deployed relayers and Core Contracts, to send, receive, validate, and track multichain messages.
 
-    [:custom-arrow: Get Started with Infrastructure](/docs/infrastructure/)
+    [:custom-arrow: Build with Core Messaging](/docs/build/core-messaging/)
 
 </div>
 --- END CONTENT ---


### PR DESCRIPTION
### Description

Refreshes the learn/infra/architecture overview page by:
- minor copy changes
- adds Next Steps section

### Checklist

- [x ] **Required** - I have added a label to this PR 🏷️
- [ x] **Required** - I have run my changes through Grammarly
- [ n/a] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
