### PR TITLE
downgrade wh version

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -7,4 +7,4 @@ repositories:
     version: 1.13.3
   wormhole:
     repository_url: https://github.com/wormhole-foundation/wormhole
-    version: 2.31.0
+    version: 2.30.0


### PR DESCRIPTION
### Description

- Small fix to wormhole version in the variables file. Version was incorrectly higher than the current one.
- Resolves #318 
- Current version `2.31.0` -> correct version `2.30.0`


### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
