### PR TITLE
add generic headers

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19915,6 +19915,8 @@ description: Discover product-specific Wormhole tutorials. Learn setup, integrat
 
 In this section, you'll find tutorials focused on individual Wormhole products. Each product folder contains detailed guides to help you integrate and use specific Wormhole services, such as Token Bridge, Wormhole Connect, and more. Whether setting up your first product or diving deeper into advanced features, these tutorials will walk you through the entire process, from installation to implementation.
 
+## Get Started
+
 <div class="grid cards" markdown>
 
 -   :octicons-arrow-switch-16:{ .lg .middle } **Connect**
@@ -23060,6 +23062,8 @@ template: root-index-page.html
 Welcome to the Wormhole tutorials section! Whether you're just getting started or looking to build advanced cross-chain applications, this collection of step-by-step tutorials will help you leverage the full power of the Wormhole ecosystem.
 
 These tutorials are designed to help you develop efficient, scalable, and innovative cross-chain applications, from integrating individual Wormhole products to creating comprehensive end-to-end solutions. Explore our tutorials to get hands-on experience with Wormhole!
+
+## Get Started
 
 <div class="grid cards" markdown>
 

--- a/tutorials/by-product/index.md
+++ b/tutorials/by-product/index.md
@@ -7,6 +7,8 @@ description: Discover product-specific Wormhole tutorials. Learn setup, integrat
 
 In this section, you'll find tutorials focused on individual Wormhole products. Each product folder contains detailed guides to help you integrate and use specific Wormhole services, such as Token Bridge, Wormhole Connect, and more. Whether setting up your first product or diving deeper into advanced features, these tutorials will walk you through the entire process, from installation to implementation.
 
+## Get Started
+
 <div class="grid cards" markdown>
 
 -   :octicons-arrow-switch-16:{ .lg .middle } **Connect**

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -10,6 +10,8 @@ Welcome to the Wormhole tutorials section! Whether you're just getting started o
 
 These tutorials are designed to help you develop efficient, scalable, and innovative cross-chain applications, from integrating individual Wormhole products to creating comprehensive end-to-end solutions. Explore our tutorials to get hands-on experience with Wormhole!
 
+## Get Started
+
 <div class="grid cards" markdown>
 
 -   :octicons-apps-16:{ .lg .middle } **By Product**


### PR DESCRIPTION
### Description

This PR adds a couple of generic headers for now. Since we're reworking the tutorials section, I didn't want to spend too much time on this. I just want to ensure that we're not showing empty TOCs anymore: https://wormhole.com/docs/tutorials/by-product/.

Additionally, as we've been improving other index pages (such as the root-level Build and Learn index pages, which contain multiple sections), restoring the TOC on these pages enhances navigation.

This PR goes with: https://github.com/papermoonio/wormhole-mkdocs/pull/203

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
