### PR TITLE
add llm introduction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This repository contains documentation for Wormhole, an interoperability platfor
 
 The content in this repository is displayed on the Wormhole documentation site generated using [mkdocs](https://www.mkdocs.org). The theme used is [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 
+## AI Resources
+
+This repository includes AI-ready `.txt` files generated from the documentation to support large language models (LLMs) and developer tools:
+
+- `llms.txt` – a plain-text index of all documentation pages with titles and URLs
+- `llms-full.txt` – the complete content of all documentation pages in a single file
+- `llms-*.txt` – category-specific files for products like NTT, Token Bridge, Connect, and others
+
+These files power AI assistants, enable semantic code search, and integrate Wormhole docs into tools like Cursor. For details, visit the [AI Resources](https://wormhole.com/docs/learn/ai-resources/){target=\_blank} page.
+
 ## Contributing
 
 If you're interested in contributing to this repository, please feel free to clone the repo, make changes, and open a PR ✨. Please review the guidelines in the .CONTRIBUTING.md file before making any changes.


### PR DESCRIPTION
### Description

- Add an introduction about LLM files in the README file.
- Do not merge until this PR is merged first: https://github.com/wormhole-foundation/wormhole-docs/pull/338


### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
