### PR TITLE
Martinh/guardians spelling fix

### DIFF
--- a/learn/infrastructure/guardians.md
+++ b/learn/infrastructure/guardians.md
@@ -11,7 +11,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -334,7 +334,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -2106,7 +2106,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -1532,7 +1532,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -2387,7 +2387,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -967,7 +967,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -941,7 +941,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -941,7 +941,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-solidity-sdk.txt
+++ b/llms-files/llms-solidity-sdk.txt
@@ -1646,7 +1646,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-token-bridge.txt
+++ b/llms-files/llms-token-bridge.txt
@@ -666,7 +666,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -7893,7 +7893,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -3833,7 +3833,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -15850,7 +15850,7 @@ Wormhole relies on a set of 19 distributed nodes that monitor the state on sever
 Guardians fulfill their role in the messaging protocol as follows: 
 
 1. Each Guardian observes messages and signs the corresponding payloads in isolation from the other Guardians
-2. Guardians combine their indpendent signatures to form a multisig
+2. Guardians combine their independent signatures to form a multisig
 3. This multisig represents proof that a majority of the Wormhole network has observed and agreed upon a state
 
 Wormhole refers to these multisigs as [Verifiable Action Approvals](/docs/learn/infrastructure/vaas/){target=\_blank} (VAAs).


### PR DESCRIPTION
### Description

Fix a grammatical spelling error on the Guardian's page.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
