### PR TITLE
Add gitignore step

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19778,8 +19778,14 @@ Now that you've written the `CrossChainSender` and `CrossChainReceiver` contract
         ```bash
         npm init -y
         ```
+
+    2. Create a `.gitignore` file to ensure your private key isn't accidentally exposed or committed to version control:
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
     
-    2. Install the necessary dependencies:
+    3. Install the necessary dependencies:
 
         ```bash
         npm install ethers dotenv readline-sync @types/readline-sync
@@ -21050,13 +21056,19 @@ In this section, we’ll guide you through initializing the project, installing 
     npm init -y
     ```
 
-2. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+2. **Create a `.gitignore` file** - ensure your private key isn't accidentally exposed or committed to version control
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
+
+3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
 
     ```bash
     npm install @wormhole-foundation/sdk dotenv tsx
     ```
 
-3. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
+4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
 
     ```bash
     touch .env
@@ -21073,7 +21085,7 @@ In this section, we’ll guide you through initializing the project, installing 
     !!! note
         Ensure your private key contains native tokens for gas on both the source and destination chains. For Sui, you must provide a mnemonic instead of a private key.
 
-4. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, set up signers for different chains, and manage transaction relays
+5. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, set up signers for different chains, and manage transaction relays
 
     1. Create the helpers file
 
@@ -21864,13 +21876,19 @@ In this section, you'll set up your project for transferring USDC across chains 
     npm init -y
     ```
 
-2. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+2. **Create a `.gitignore` file** - ensure your private key isn't accidentally exposed or committed to version control
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
+
+3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
 
     ```bash
     npm install @wormhole-foundation/sdk dotenv
     ```
 
-3. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
+4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
 
     ```bash
     touch .env
@@ -21886,7 +21904,7 @@ In this section, you'll set up your project for transferring USDC across chains 
     !!! note
         Ensure your private key contains USDC funds and native tokens for gas on both the source and destination chains.
 
-4. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, setting up signers for different chains, and managing transaction relays
+5. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, setting up signers for different chains, and managing transaction relays
 
     1. Create the helpers file
 
@@ -21962,7 +21980,7 @@ export async function getSigner<n c="" chain="" extends="" network,="">(
         - **`getEnv`** - this function fetches environment variables like your private key from the `.env` file
         - **`getSigner`** - based on the chain you're working with (EVM, Solana, etc.), this function retrieves a signer for that specific platform. The signer is responsible for signing transactions and interacting with the blockchain. It securely uses the private key stored in your `.env` file
 
-5. **Create the main script** - create a new file named `manual-transfer.ts` to hold your script for transferring USDC across chains
+6. **Create the main script** - create a new file named `manual-transfer.ts` to hold your script for transferring USDC across chains
 
     1. Create the `manual-transfer.ts` file in the `src` directory
 

--- a/tutorials/solidity-sdk/cross-chain-token-contracts.md
+++ b/tutorials/solidity-sdk/cross-chain-token-contracts.md
@@ -269,8 +269,14 @@ Now that you've written the `CrossChainSender` and `CrossChainReceiver` contract
         ```bash
         npm init -y
         ```
+
+    2. Create a `.gitignore` file to ensure your private key isn't accidentally exposed or committed to version control:
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
     
-    2. Install the necessary dependencies:
+    3. Install the necessary dependencies:
 
         ```bash
         npm install ethers dotenv readline-sync @types/readline-sync

--- a/tutorials/typescript-sdk/tokens-via-token-bridge.md
+++ b/tutorials/typescript-sdk/tokens-via-token-bridge.md
@@ -47,13 +47,19 @@ In this section, we’ll guide you through initializing the project, installing 
     npm init -y
     ```
 
-2. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+2. **Create a `.gitignore` file** - ensure your private key isn't accidentally exposed or committed to version control
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
+
+3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
 
     ```bash
     npm install @wormhole-foundation/sdk dotenv tsx
     ```
 
-3. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
+4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
 
     ```bash
     touch .env
@@ -70,7 +76,7 @@ In this section, we’ll guide you through initializing the project, installing 
     !!! note
         Ensure your private key contains native tokens for gas on both the source and destination chains. For Sui, you must provide a mnemonic instead of a private key.
 
-4. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, set up signers for different chains, and manage transaction relays
+5. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, set up signers for different chains, and manage transaction relays
 
     1. Create the helpers file
 

--- a/tutorials/typescript-sdk/usdc-via-cctp.md
+++ b/tutorials/typescript-sdk/usdc-via-cctp.md
@@ -50,13 +50,19 @@ In this section, you'll set up your project for transferring USDC across chains 
     npm init -y
     ```
 
-2. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+2. **Create a `.gitignore` file** - ensure your private key isn't accidentally exposed or committed to version control
+
+    ```bash
+    echo ".env" >> .gitignore
+    ```
+
+3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
 
     ```bash
     npm install @wormhole-foundation/sdk dotenv
     ```
 
-3. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
+4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project
 
     ```bash
     touch .env
@@ -72,7 +78,7 @@ In this section, you'll set up your project for transferring USDC across chains 
     !!! note
         Ensure your private key contains USDC funds and native tokens for gas on both the source and destination chains.
 
-4. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, setting up signers for different chains, and managing transaction relays
+5. **Create a `helpers.ts` file** - to simplify the interaction between chains, create a file to store utility functions for fetching your private key, setting up signers for different chains, and managing transaction relays
 
     1. Create the helpers file
 
@@ -90,7 +96,7 @@ In this section, you'll set up your project for transferring USDC across chains 
         - **`getEnv`** - this function fetches environment variables like your private key from the `.env` file
         - **`getSigner`** - based on the chain you're working with (EVM, Solana, etc.), this function retrieves a signer for that specific platform. The signer is responsible for signing transactions and interacting with the blockchain. It securely uses the private key stored in your `.env` file
 
-5. **Create the main script** - create a new file named `manual-transfer.ts` to hold your script for transferring USDC across chains
+6. **Create the main script** - create a new file named `manual-transfer.ts` to hold your script for transferring USDC across chains
 
     1. Create the `manual-transfer.ts` file in the `src` directory
 


### PR DESCRIPTION
### Description

This PR adds a step to add a .gitignore to these tutorials. If the user starts from the demo repo README of these tutorials, they will clone the repo and have a .gitignore. However, if they start from the tutorial, there is no mention of cloning the repo and they start a fresh project. These instructions lacked use of .gitignore which could cause exposure of private keys. 

This is a temp fix and part of a larger initiative to remove the use of plain-text private keys in .env files in guides and tutorials. 

This PR is only intended to address these specific issues. If you wish to make any additional changes to these pages, please open a ticket. 

### Checklist

- [ x] **Required** - I have added a label to this PR 🏷️
- [x ] **Required** - I have run my changes through Grammarly
- [n/a ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
