### PR TITLE
Martinh/add ntt install path step

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -642,9 +642,9 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
-!!! warning "Command not found?"
-    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
-
+??? warning "Command not found?"
+    If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) is installed and that its binary directory is included in your shell’s PATH.
+    
     Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
 
     ```bash

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -642,6 +642,17 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
+!!! warning "Command not found?"
+    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
+
+    Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
+
+    ```bash
+    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+    ```
+
+    Then, restart your terminal or run `source ~/.zshrc`.
+
 ## Initialize a New NTT Project
 
 1. Once the CLI is installed, scaffold a new project by running:

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -5335,9 +5335,9 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
-!!! warning "Command not found?"
-    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
-
+??? warning "Command not found?"
+    If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) is installed and that its binary directory is included in your shell’s PATH.
+    
     Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
 
     ```bash

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -5335,6 +5335,17 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
+!!! warning "Command not found?"
+    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
+
+    Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
+
+    ```bash
+    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+    ```
+
+    Then, restart your terminal or run `source ~/.zshrc`.
+
 ## Initialize a New NTT Project
 
 1. Once the CLI is installed, scaffold a new project by running:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12272,9 +12272,9 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
-!!! warning "Command not found?"
-    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
-
+??? warning "Command not found?"
+    If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) is installed and that its binary directory is included in your shell’s PATH.
+    
     Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
 
     ```bash

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12272,6 +12272,17 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
+!!! warning "Command not found?"
+    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
+
+    Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
+
+    ```bash
+    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+    ```
+
+    Then, restart your terminal or run `source ~/.zshrc`.
+
 ## Initialize a New NTT Project
 
 1. Once the CLI is installed, scaffold a new project by running:

--- a/products/native-token-transfers/get-started.md
+++ b/products/native-token-transfers/get-started.md
@@ -146,6 +146,17 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
+!!! warning "Command not found?"
+    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
+
+    Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
+
+    ```bash
+    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+    ```
+
+    Then, restart your terminal or run `source ~/.zshrc`.
+
 ## Initialize a New NTT Project
 
 1. Once the CLI is installed, scaffold a new project by running:

--- a/products/native-token-transfers/get-started.md
+++ b/products/native-token-transfers/get-started.md
@@ -146,9 +146,9 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
     ntt --version
     ```
 
-!!! warning "Command not found?"
-    If the `ntt` command is not recognized after installation, you may need to add the binary to your shell's PATH.
-
+??? warning "Command not found?"
+    If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) is installed and that its binary directory is included in your shell’s PATH.
+    
     Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
 
     ```bash


### PR DESCRIPTION
### Description

- Added a step to update the user's shell configuration (e.g., .zshrc, .bashrc) to include Bun’s binary path (`$HOME/.bun/bin`) after installing the NTT CLI
- Ensures ntt is available in future terminal sessions without requiring a manual path export
- Suggestion was brought up by an external contributor to improve the onboarding experience and prevent confusion during setup

External contributor's PR: https://github.com/wormhole-foundation/wormhole-docs/pull/429

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
