### PR TITLE
Martinh/sol devnet

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -983,11 +983,6 @@ Deploying NTT with the CLI on Solana follows a structured process:
                     solana config set -um
                     ```
 
-                === "Testnet"
-                    ```bash
-                    solana config set -ut
-                    ```
-
                 === "Devnet"
                     ```bash
                     solana config set -ud
@@ -1087,8 +1082,9 @@ Follow these steps (or see the [Get Started guide](/docs/products/native-token-t
 
     This generates a `deployment.json` file where your deployment settings will be stored.
 
-    !!! note
-        Testnet deployment settings work for both Solana Testnet and Devnet networks.
+!!! note
+    When deploying NTT to Solana in `Testnet` mode, you must use [**Devnet tokens**](https://faucet.solana.com/){target=\_blank}.  
+    Solana's official Testnet cluster is not supported for token creation or deployment in NTT.
 
 ### Generate an NTT Program Key Pair
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -5676,11 +5676,6 @@ Deploying NTT with the CLI on Solana follows a structured process:
                     solana config set -um
                     ```
 
-                === "Testnet"
-                    ```bash
-                    solana config set -ut
-                    ```
-
                 === "Devnet"
                     ```bash
                     solana config set -ud
@@ -5780,8 +5775,9 @@ Follow these steps (or see the [Get Started guide](/docs/products/native-token-t
 
     This generates a `deployment.json` file where your deployment settings will be stored.
 
-    !!! note
-        Testnet deployment settings work for both Solana Testnet and Devnet networks.
+!!! note
+    When deploying NTT to Solana in `Testnet` mode, you must use [**Devnet tokens**](https://faucet.solana.com/){target=\_blank}.  
+    Solana's official Testnet cluster is not supported for token creation or deployment in NTT.
 
 ### Generate an NTT Program Key Pair
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -12617,11 +12617,6 @@ Deploying NTT with the CLI on Solana follows a structured process:
                     solana config set -um
                     ```
 
-                === "Testnet"
-                    ```bash
-                    solana config set -ut
-                    ```
-
                 === "Devnet"
                     ```bash
                     solana config set -ud
@@ -12721,8 +12716,9 @@ Follow these steps (or see the [Get Started guide](/docs/products/native-token-t
 
     This generates a `deployment.json` file where your deployment settings will be stored.
 
-    !!! note
-        Testnet deployment settings work for both Solana Testnet and Devnet networks.
+!!! note
+    When deploying NTT to Solana in `Testnet` mode, you must use [**Devnet tokens**](https://faucet.solana.com/){target=\_blank}.  
+    Solana's official Testnet cluster is not supported for token creation or deployment in NTT.
 
 ### Generate an NTT Program Key Pair
 

--- a/products/native-token-transfers/guides/deploy-to-solana.md
+++ b/products/native-token-transfers/guides/deploy-to-solana.md
@@ -51,11 +51,6 @@ Deploying NTT with the CLI on Solana follows a structured process:
                     solana config set -um
                     ```
 
-                === "Testnet"
-                    ```bash
-                    solana config set -ut
-                    ```
-
                 === "Devnet"
                     ```bash
                     solana config set -ud
@@ -118,8 +113,9 @@ The [NTT CLI](/docs/products/native-token-transfers/reference/cli-commands/){tar
 
     --8<-- 'text/products/native-token-transfers/guides/install-ntt-project.md'
 
-    !!! note
-        Testnet deployment settings work for both Solana Testnet and Devnet networks.
+!!! note
+    When deploying NTT to Solana in `Testnet` mode, you must use [**Devnet tokens**](https://faucet.solana.com/){target=\_blank}.  
+    Solana's official Testnet cluster is not supported for token creation or deployment in NTT.
 
 ### Generate an NTT Program Key Pair
 


### PR DESCRIPTION
### Description

This PR adds a warning to the Solana deployment guide clarifying that when using `ntt init Testnet`, developers must use Devnet tokens. 

Solana’s official Testnet is not supported for token creation or NTT deployments. The warning is placed in the “Set Up NTT” section to align with where users begin configuring deployments.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
