### PR TITLE
Martih/connect ntt config

### DIFF
--- a/.snippets/code/products/connect/configuration/data/configure-ntt.tsx
+++ b/.snippets/code/products/connect/configuration/data/configure-ntt.tsx
@@ -1,0 +1,65 @@
+import WormholeConnect, { type config } from '@wormhole-foundation/wormhole-connect';
+import { nttRoutes } from '@wormhole-foundation/wormhole-connect/ntt';
+
+const wormholeConfig: config.WormholeConnectConfig = {
+	network: 'Testnet',
+	chains: ['Solana', 'BaseSepolia'],
+	tokens: ['WSV'],
+	ui: {
+		title: 'Wormhole NTT UI',
+		defaultInputs: {
+			fromChain: 'Solana',
+			toChain: 'BaseSepolia',
+		},
+	},
+	routes: [
+		...nttRoutes({
+			tokens: {
+				WSV_NTT: [
+					{
+						chain: 'Solana',
+						manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
+						token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+						transceiver: [
+							{
+								address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
+								type: 'wormhole',
+							},
+						],
+					},
+					{
+						chain: 'BaseSepolia',
+						manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
+						token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+						transceiver: [
+							{
+								address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
+								type: 'wormhole',
+							},
+						],
+					},
+				],
+			},
+		}),
+	],
+	tokensConfig: {
+		WSVsol: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'Solana',
+				address: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+		WSVbase: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'BaseSepolia',
+				address: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+	},
+};

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -514,6 +514,85 @@ const config: WormholeConnectConfig = {
 };
 ```
 
+### Configuring Native Token Transfers (NTT)
+
+Wormhole Connect supports [Native Token Transfers (NTT)](/docs/products/native-token-transfers/overview/){target=_blank}, which allow the same token to move natively between supported chains using canonical contracts and transceivers.
+
+To enable NTT, pass a token configuration object to the `nttRoutes(...)` helper and include the result in the `routes` array using the spread operator.
+
+```typescript
+import WormholeConnect, { type config } from '@wormhole-foundation/wormhole-connect';
+import { nttRoutes } from '@wormhole-foundation/wormhole-connect/ntt';
+
+const wormholeConfig: config.WormholeConnectConfig = {
+	network: 'Testnet',
+	chains: ['Solana', 'BaseSepolia'],
+	tokens: ['WSV'],
+	ui: {
+		title: 'Wormhole NTT UI',
+		defaultInputs: {
+			fromChain: 'Solana',
+			toChain: 'BaseSepolia',
+		},
+	},
+	routes: [
+		...nttRoutes({
+			tokens: {
+				WSV_NTT: [
+					{
+						chain: 'Solana',
+						manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
+						token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+						transceiver: [
+							{
+								address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
+								type: 'wormhole',
+							},
+						],
+					},
+					{
+						chain: 'BaseSepolia',
+						manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
+						token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+						transceiver: [
+							{
+								address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
+								type: 'wormhole',
+							},
+						],
+					},
+				],
+			},
+		}),
+	],
+	tokensConfig: {
+		WSVsol: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'Solana',
+				address: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+		WSVbase: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'BaseSepolia',
+				address: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+	},
+};
+```
+
+!!! note 
+    Each token listed in `nttRoutes` must also have a corresponding entry in [`tokensConfig`](#custom-tokens), either as a built-in or custom token. These entries must include `symbol`, `decimals`, and the `tokenId`.
+
+For a complete working example of NTT configuration in Wormhole Connect, see the [ntt-connect demo repository](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}.
+
 ### Whitelisting Tokens {: #whitelisting-tokens }
 
 Connect offers a list of built-in tokens by default. You can see it below:

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -3491,6 +3491,85 @@ const config: WormholeConnectConfig = {
 };
 ```
 
+### Configuring Native Token Transfers (NTT)
+
+Wormhole Connect supports [Native Token Transfers (NTT)](/docs/products/native-token-transfers/overview/){target=_blank}, which allow the same token to move natively between supported chains using canonical contracts and transceivers.
+
+To enable NTT, pass a token configuration object to the `nttRoutes(...)` helper and include the result in the `routes` array using the spread operator.
+
+```typescript
+import WormholeConnect, { type config } from '@wormhole-foundation/wormhole-connect';
+import { nttRoutes } from '@wormhole-foundation/wormhole-connect/ntt';
+
+const wormholeConfig: config.WormholeConnectConfig = {
+	network: 'Testnet',
+	chains: ['Solana', 'BaseSepolia'],
+	tokens: ['WSV'],
+	ui: {
+		title: 'Wormhole NTT UI',
+		defaultInputs: {
+			fromChain: 'Solana',
+			toChain: 'BaseSepolia',
+		},
+	},
+	routes: [
+		...nttRoutes({
+			tokens: {
+				WSV_NTT: [
+					{
+						chain: 'Solana',
+						manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
+						token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+						transceiver: [
+							{
+								address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
+								type: 'wormhole',
+							},
+						],
+					},
+					{
+						chain: 'BaseSepolia',
+						manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
+						token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+						transceiver: [
+							{
+								address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
+								type: 'wormhole',
+							},
+						],
+					},
+				],
+			},
+		}),
+	],
+	tokensConfig: {
+		WSVsol: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'Solana',
+				address: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+		WSVbase: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'BaseSepolia',
+				address: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+	},
+};
+```
+
+!!! note 
+    Each token listed in `nttRoutes` must also have a corresponding entry in [`tokensConfig`](#custom-tokens), either as a built-in or custom token. These entries must include `symbol`, `decimals`, and the `tokenId`.
+
+For a complete working example of NTT configuration in Wormhole Connect, see the [ntt-connect demo repository](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}.
+
 ### Whitelisting Tokens {: #whitelisting-tokens }
 
 Connect offers a list of built-in tokens by default. You can see it below:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4642,6 +4642,85 @@ const config: WormholeConnectConfig = {
 };
 ```
 
+### Configuring Native Token Transfers (NTT)
+
+Wormhole Connect supports [Native Token Transfers (NTT)](/docs/products/native-token-transfers/overview/){target=_blank}, which allow the same token to move natively between supported chains using canonical contracts and transceivers.
+
+To enable NTT, pass a token configuration object to the `nttRoutes(...)` helper and include the result in the `routes` array using the spread operator.
+
+```typescript
+import WormholeConnect, { type config } from '@wormhole-foundation/wormhole-connect';
+import { nttRoutes } from '@wormhole-foundation/wormhole-connect/ntt';
+
+const wormholeConfig: config.WormholeConnectConfig = {
+	network: 'Testnet',
+	chains: ['Solana', 'BaseSepolia'],
+	tokens: ['WSV'],
+	ui: {
+		title: 'Wormhole NTT UI',
+		defaultInputs: {
+			fromChain: 'Solana',
+			toChain: 'BaseSepolia',
+		},
+	},
+	routes: [
+		...nttRoutes({
+			tokens: {
+				WSV_NTT: [
+					{
+						chain: 'Solana',
+						manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
+						token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+						transceiver: [
+							{
+								address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
+								type: 'wormhole',
+							},
+						],
+					},
+					{
+						chain: 'BaseSepolia',
+						manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
+						token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+						transceiver: [
+							{
+								address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
+								type: 'wormhole',
+							},
+						],
+					},
+				],
+			},
+		}),
+	],
+	tokensConfig: {
+		WSVsol: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'Solana',
+				address: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+		WSVbase: {
+			symbol: 'WSV',
+			tokenId: {
+				chain: 'BaseSepolia',
+				address: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+			},
+			icon: 'https://wormhole.com/token.png',
+			decimals: 9,
+		},
+	},
+};
+```
+
+!!! note 
+    Each token listed in `nttRoutes` must also have a corresponding entry in [`tokensConfig`](#custom-tokens), either as a built-in or custom token. These entries must include `symbol`, `decimals`, and the `tokenId`.
+
+For a complete working example of NTT configuration in Wormhole Connect, see the [ntt-connect demo repository](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}.
+
 ### Whitelisting Tokens {: #whitelisting-tokens }
 
 Connect offers a list of built-in tokens by default. You can see it below:

--- a/products/connect/configuration/data.md
+++ b/products/connect/configuration/data.md
@@ -108,40 +108,18 @@ See the [Connect source code](https://github.com/wormhole-foundation/wormhole-co
 
 ### Configuring Native Token Transfers (NTT)
 
-Wormhole Connect supports [NTT](/docs/products/native-token-transfers/overview/){target=\_blank}, enabling the same token to be transferred natively across multiple chains without wrapping.
+Wormhole Connect supports [Native Token Transfers (NTT)](/docs/products/native-token-transfers/overview/){target=_blank}, which allow the same token to move natively between supported chains using canonical contracts and transceivers.
 
-To enable NTT routes, use the `nttRoutes(...)` helper and pass your custom NTT configuration directly into it. This will return the appropriate route constructors, which you can spread into your routes array.
+To enable NTT, pass a token configuration object to the `nttRoutes(...)` helper and include the result in the `routes` array using the spread operator.
 
-```ts
-import {
-  nttRoutes,
-} from '@wormhole-foundation/connect-sdk';
-
-const config: WormholeConnectConfig = {
-  routes: [
-    ...nttRoutes({
-      tokens: {
-        MyToken: [
-          {
-            chain: 'Ethereum',
-            token: '0xMyEthereumTokenAddress',
-          },
-          {
-            chain: 'Solana',
-            token: 'MySolanaTokenMintAddress',
-          },
-        ],
-      },
-    }),
-    // other routes
-  ],
-};
+```typescript
+--8<-- 'code/products/connect/configuration/data/configure-ntt.tsx'
 ```
 
-Each key inside `tokens` represents a canonical token supported on multiple chains. Each array entry includes the `chain` and the token's contract address or mint address on that chain.
+!!! note 
+    Each token listed in `nttRoutes` must also have a corresponding entry in [`tokensConfig`](#custom-tokens), either as a built-in or custom token. These entries must include `symbol`, `decimals`, and the `tokenId`.
 
-!!! note
-    Each token address specified in the NTT config must have a corresponding entry in [`tokensConfig`](#custom-tokens), whether it is a built-in or custom token.
+For a complete working example of NTT configuration in Wormhole Connect, see the [ntt-connect demo repository](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}.
 
 ### Whitelisting Tokens {: #whitelisting-tokens }
 

--- a/products/connect/configuration/data.md
+++ b/products/connect/configuration/data.md
@@ -106,6 +106,43 @@ See the [Connect source code](https://github.com/wormhole-foundation/wormhole-co
 --8<-- 'code/products/connect/configuration/data/add-token.tsx'
 ```
 
+### Configuring Native Token Transfers (NTT)
+
+Wormhole Connect supports [NTT](/docs/products/native-token-transfers/overview/){target=\_blank}, enabling the same token to be transferred natively across multiple chains without wrapping.
+
+To enable NTT routes, use the `nttRoutes(...)` helper and pass your custom NTT configuration directly into it. This will return the appropriate route constructors, which you can spread into your routes array.
+
+```ts
+import {
+  nttRoutes,
+} from '@wormhole-foundation/connect-sdk';
+
+const config: WormholeConnectConfig = {
+  routes: [
+    ...nttRoutes({
+      tokens: {
+        MyToken: [
+          {
+            chain: 'Ethereum',
+            token: '0xMyEthereumTokenAddress',
+          },
+          {
+            chain: 'Solana',
+            token: 'MySolanaTokenMintAddress',
+          },
+        ],
+      },
+    }),
+    // other routes
+  ],
+};
+```
+
+Each key inside `tokens` represents a canonical token supported on multiple chains. Each array entry includes the `chain` and the token's contract address or mint address on that chain.
+
+!!! note
+    Each token address specified in the NTT config must have a corresponding entry in [`tokensConfig`](#custom-tokens), whether it is a built-in or custom token.
+
 ### Whitelisting Tokens {: #whitelisting-tokens }
 
 Connect offers a list of built-in tokens by default. You can see it below:


### PR DESCRIPTION
### Description

This pull request introduces support for configuring Native Token Transfers (NTT) in Wormhole Connect. It includes the addition of configuration examples, documentation updates, and token setup for seamless native token movement across supported chains.

### Added NTT Configuration and Documentation

1. **NTT Configuration in Code**:
   - Added a comprehensive configuration for Native Token Transfers (NTT) in `configure-ntt.tsx`. This includes defining `wormholeConfig` with testnet details, supported chains (`Solana` and `BaseSepolia`), token configurations, and routes using the `nttRoutes` helper.

2. **Documentation Updates**:
   - Added a detailed guide for configuring NTT in multiple documentation files (`llms-connect.txt`, `llms-transfer.txt`, `llms-full.txt`, and `data.md`). These updates explain the purpose of NTT, how to use the `nttRoutes` helper, and the required `tokensConfig` entries. [[1]](diffhunk://#diff-6c27d13b13970bc40f4abe2ac59f12147345db67dc1c40657f0ad253a45f62d6R517-R595) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R3494-R3572) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R4645-R4723) [[4]](diffhunk://#diff-5649fd17310bf9cb1dfde0451af235d69599e6fcf97e9235f0445d191a525a57R109-R123)

3. **Example References**:
   - Included links to a demo repository (`ntt-connect demo repository`) showcasing a complete working example of NTT configuration. [[1]](diffhunk://#diff-6c27d13b13970bc40f4abe2ac59f12147345db67dc1c40657f0ad253a45f62d6R517-R595) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R3494-R3572) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R4645-R4723) [[4]](diffhunk://#diff-5649fd17310bf9cb1dfde0451af235d69599e6fcf97e9235f0445d191a525a57R109-R123)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
