### PR TITLE
restore ntt vs token bridge comparison

### DIFF
--- a/products/overview.md
+++ b/products/overview.md
@@ -45,6 +45,21 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
+## Choose a Transfer Mechanism
+
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/native-token-transfers/overview/){target=\_blank} and [Token Bridge](/docs/products/token-bridge/overview/){target=\_blank}. Both options carry a distinct integration path and feature set depending on your requirements, as outlined in the following sections.
+
+| Feature                | Native Token Transfers                                                     | Token Bridge                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting, and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole Token Bridge contract, upgradeable via a 13/19 Guardian governance process. |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
+
+
 In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Token Bridge and how to select the best option for your use case:
 
 <style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>


### PR DESCRIPTION
This pull request adds a new section to the `products/overview.md` file, introducing and explaining the two distinct asset transfer mechanisms provided by Wormhole: Native Token Transfers (NTT) and Token Bridge. The section includes a comparison table detailing their features, use cases, security measures, contract ownership, token contracts, integration paths, and examples.

Key changes:

### New section on transfer mechanisms:
* Added a comprehensive explanation of Wormhole's two transfer mechanisms: Native Token Transfers (NTT) and Token Bridge, along with links to their respective documentation.
* Included a detailed comparison table highlighting the differences between NTT and Token Bridge, covering aspects such as best use cases, mechanisms, security, contract ownership, token contracts, integration complexity, and examples.### Description

Please explain the changes this PR addresses here.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
