### PR TITLE
Martinh/demo sdk version

### DIFF
--- a/llms-files/llms-token-bridge.txt
+++ b/llms-files/llms-token-bridge.txt
@@ -149,10 +149,10 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies:
+2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
-    npm install @wormhole-foundation/sdk
+    npm install @wormhole-foundation/sdk@2.4.0
     npm install -D tsx typescript
     ```
 
@@ -1446,10 +1446,11 @@ In this section, we’ll guide you through initializing the project, installing 
     echo ".env" >> .gitignore
     ```
 
-3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+3. **Install dependencies** - install the required dependencies. In this tutorial, we will use the TypeScript SDK version `2.4.0`, along with helper libraries
+
 
     ```bash
-    npm install @wormhole-foundation/sdk dotenv tsx
+    npm install @wormhole-foundation/sdk@2.4.0 dotenv tsx
     ```
 
 4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project

--- a/llms-files/llms-token-bridge.txt
+++ b/llms-files/llms-token-bridge.txt
@@ -149,7 +149,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, you’ll use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/llms-files/llms-token-bridge.txt
+++ b/llms-files/llms-token-bridge.txt
@@ -149,7 +149,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17537,10 +17537,10 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies:
+2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
-    npm install @wormhole-foundation/sdk
+    npm install @wormhole-foundation/sdk@2.4.0
     npm install -D tsx typescript
     ```
 
@@ -19041,10 +19041,11 @@ In this section, we’ll guide you through initializing the project, installing 
     echo ".env" >> .gitignore
     ```
 
-3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+3. **Install dependencies** - install the required dependencies. In this tutorial, we will use the TypeScript SDK version `2.4.0`, along with helper libraries
+
 
     ```bash
-    npm install @wormhole-foundation/sdk dotenv tsx
+    npm install @wormhole-foundation/sdk@2.4.0 dotenv tsx
     ```
 
 4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17537,7 +17537,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, you’ll use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17537,7 +17537,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/products/token-bridge/get-started.md
+++ b/products/token-bridge/get-started.md
@@ -36,10 +36,10 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies:
+2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
-    npm install @wormhole-foundation/sdk
+    npm install @wormhole-foundation/sdk@2.4.0
     npm install -D tsx typescript
     ```
 

--- a/products/token-bridge/get-started.md
+++ b/products/token-bridge/get-started.md
@@ -36,7 +36,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/products/token-bridge/get-started.md
+++ b/products/token-bridge/get-started.md
@@ -36,7 +36,7 @@ This guide uses a Solana wallet with [devnet SOL](https://faucet.solana.com/){ta
     npm init -y
     ```
 
-2. Install the required dependencies. In this guide, we will use the TypeScript SDK version `2.4.0`:
+2. Install the required dependencies. In this guide, you’ll use the TypeScript SDK version `2.4.0`:
 
     ```bash
     npm install @wormhole-foundation/sdk@2.4.0

--- a/products/token-bridge/tutorials/transfer-workflow.md
+++ b/products/token-bridge/tutorials/transfer-workflow.md
@@ -52,10 +52,11 @@ In this section, we’ll guide you through initializing the project, installing 
     echo ".env" >> .gitignore
     ```
 
-3. **Install dependencies** - install the required dependencies, including the Wormhole SDK and helper libraries
+3. **Install dependencies** - install the required dependencies. In this tutorial, we will use the TypeScript SDK version `2.4.0`, along with helper libraries
+
 
     ```bash
-    npm install @wormhole-foundation/sdk dotenv tsx
+    npm install @wormhole-foundation/sdk@2.4.0 dotenv tsx
     ```
 
 4. **Set up environment variables** - to securely store your private key, create a `.env` file in the root of your project


### PR DESCRIPTION
### Description

This pull request updates the documentation across multiple files to specify the use of the TypeScript SDK version `2.4.0` for consistency and clarity. The changes ensure that the exact version of the SDK is explicitly mentioned in installation steps.

### Documentation updates:

* [`llms-files/llms-token-bridge.txt`](diffhunk://#diff-5beab6734f67ba9a360c49556aa7f2e3701da2e893bbcc0bc77e76201198c27aL152-R155): Updated dependency installation instructions to specify the TypeScript SDK version `2.4.0` in two sections. [[1]](diffhunk://#diff-5beab6734f67ba9a360c49556aa7f2e3701da2e893bbcc0bc77e76201198c27aL152-R155) [[2]](diffhunk://#diff-5beab6734f67ba9a360c49556aa7f2e3701da2e893bbcc0bc77e76201198c27aL1449-R1453)
* [`llms-full.txt`](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L17540-R17543): Updated dependency installation instructions to specify the TypeScript SDK version `2.4.0` in two sections. [[1]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L17540-R17543) [[2]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L19044-R19048)
* [`products/token-bridge/get-started.md`](diffhunk://#diff-254951891fe9cfd21ef266e1ffbbf97b220db340c5035b05b2e5df84fd756cc8L39-R42): Updated dependency installation instructions to specify the TypeScript SDK version `2.4.0`.
* [`products/token-bridge/tutorials/transfer-workflow.md`](diffhunk://#diff-33fc1e253c81821fab278e7783eb84ff035cb5fd5295630ddf8f5612c97268b1L55-R59): Updated dependency installation instructions to specify the TypeScript SDK version `2.4.0`.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
