### PR TITLE
Remove ntt cli video

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -254,8 +254,6 @@ To use NTT, you must have a token already deployed on the source and destination
 
 ## Install NTT CLI
 
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/ltZmeyjUxRk?start=1685' frameborder='0' allowfullscreen></iframe></div>
-
 The NTT CLI is recommended to deploy and manage your cross-chain token configuration.
 
 1. Run the installation command in your terminal:

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -995,8 +995,6 @@ To use NTT, you must have a token already deployed on the source and destination
 
 ## Install NTT CLI
 
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/ltZmeyjUxRk?start=1685' frameborder='0' allowfullscreen></iframe></div>
-
 The NTT CLI is recommended to deploy and manage your cross-chain token configuration.
 
 1. Run the installation command in your terminal:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13214,8 +13214,6 @@ To use NTT, you must have a token already deployed on the source and destination
 
 ## Install NTT CLI
 
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/ltZmeyjUxRk?start=1685' frameborder='0' allowfullscreen></iframe></div>
-
 The NTT CLI is recommended to deploy and manage your cross-chain token configuration.
 
 1. Run the installation command in your terminal:

--- a/products/native-token-transfers/get-started.md
+++ b/products/native-token-transfers/get-started.md
@@ -136,8 +136,6 @@ To use NTT, you must have a token already deployed on the source and destination
 
 ## Install NTT CLI
 
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/ltZmeyjUxRk?start=1685' frameborder='0' allowfullscreen></iframe></div>
-
 The NTT CLI is recommended to deploy and manage your cross-chain token configuration.
 
 1. Run the installation command in your terminal:


### PR DESCRIPTION
### Description

Remove ntt cli video as it is not up to date

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
