### PR TITLE
Spl token clarification

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -64,7 +64,7 @@ Native Token Transfers primarily support ERC-20 tokens, the most widely used sta
 
 The NttManager is a contract that oversees the secure and reliable transfer of native tokens across supported blockchains. It leverages the standard IERC20 interface and OpenZeppelin’s SafeERC20 library to interact with these tokens securely across chains.
 
-NTT does not currently support token standards like ERC-721 (non-fungible tokens), ERC-1155 (a multi-token standard), or SPL-based tokens, such as Metaplex NFTs. Support is currently limited to ERC-20 tokens.
+NTT does not currently support non-fungible tokens (NFTs) or multi-token standards like ERC-1155. Support is limited to ERC-20 tokens.
 
 ## Deployment Process
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -240,7 +240,7 @@ Native Token Transfers primarily support ERC-20 tokens, the most widely used sta
 
 The NttManager is a contract that oversees the secure and reliable transfer of native tokens across supported blockchains. It leverages the standard IERC20 interface and OpenZeppelin’s SafeERC20 library to interact with these tokens securely across chains.
 
-NTT does not currently support token standards like ERC-721 (non-fungible tokens), ERC-1155 (a multi-token standard), or SPL-based tokens, such as Metaplex NFTs. Support is currently limited to ERC-20 tokens.
+NTT does not currently support non-fungible tokens (NFTs) or multi-token standards like ERC-1155. Support is limited to ERC-20 tokens.
 
 ## Deployment Process
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14313,7 +14313,7 @@ Native Token Transfers primarily support ERC-20 tokens, the most widely used sta
 
 The NttManager is a contract that oversees the secure and reliable transfer of native tokens across supported blockchains. It leverages the standard IERC20 interface and OpenZeppelin’s SafeERC20 library to interact with these tokens securely across chains.
 
-NTT does not currently support token standards like ERC-721 (non-fungible tokens), ERC-1155 (a multi-token standard), or SPL-based tokens, such as Metaplex NFTs. Support is currently limited to ERC-20 tokens.
+NTT does not currently support non-fungible tokens (NFTs) or multi-token standards like ERC-1155. Support is limited to ERC-20 tokens.
 
 ## Deployment Process
 

--- a/products/native-token-transfers/overview.md
+++ b/products/native-token-transfers/overview.md
@@ -29,7 +29,7 @@ Native Token Transfers primarily support ERC-20 tokens, the most widely used sta
 
 The NttManager is a contract that oversees the secure and reliable transfer of native tokens across supported blockchains. It leverages the standard IERC20 interface and OpenZeppelin’s SafeERC20 library to interact with these tokens securely across chains.
 
-NTT does not currently support token standards like ERC-721 (non-fungible tokens), ERC-1155 (a multi-token standard), or SPL-based tokens, such as Metaplex NFTs. Support is currently limited to ERC-20 tokens.
+NTT does not currently support non-fungible tokens (NFTs) or multi-token standards like ERC-1155. Support is limited to ERC-20 tokens.
 
 ## Deployment Process
 


### PR DESCRIPTION
### Description

This pull request makes a minor documentation update to clarify the types of token standards supported by Native Token Transfers (NTT). The change streamlines the language to more clearly state that only ERC-20 tokens are supported, removing references to SPL-based tokens and simplifying the explanation regarding NFTs and multi-token standards.

Most important change:

* Documentation in `llms-files/llms-ntt.txt`, `llms-files/llms-transfer.txt`, `llms-full.txt`, and `products/native-token-transfers/overview.md` was updated to clarify that NTT does not support non-fungible tokens (NFTs) or multi-token standards like ERC-1155, and is limited to ERC-20 tokens. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL67-R67) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L243-R243) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L14316-R14316) [[4]](diffhunk://#diff-5a8c2bd9cdb13644cae2977e393b34c93317f72c8ffc91ddf0e0571df0ae322eL32-R32)

### Checklist

- [ ] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
