### PR TITLE
Martinh/faq style fix

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -6892,17 +6892,17 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
 ```
 
-2. **Transfer AdminCap object** over to a multisig:
+2. Transfer `AdminCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
 ```
 
-3. **Transfer UpgradeCap object** over to a multisig:
+3. Transfer `UpgradeCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
 ```
 
-4. **Check new owner** of AdminCap object 
+4. Check new owner of `AdminCap` object:
 ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13057,17 +13057,17 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
 ```
 
-2. **Transfer AdminCap object** over to a multisig:
+2. Transfer `AdminCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
 ```
 
-3. **Transfer UpgradeCap object** over to a multisig:
+3. Transfer `UpgradeCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
 ```
 
-4. **Check new owner** of AdminCap object 
+4. Check new owner of `AdminCap` object:
 ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17798,17 +17798,17 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
 ```
 
-2. **Transfer AdminCap object** over to a multisig:
+2. Transfer `AdminCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
 ```
 
-3. **Transfer UpgradeCap object** over to a multisig:
+3. Transfer `UpgradeCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
 ```
 
-4. **Check new owner** of AdminCap object 
+4. Check new owner of `AdminCap` object:
 ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -40,17 +40,17 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
 ```
 
-2. **Transfer AdminCap object** over to a multisig:
+2. Transfer `AdminCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
 ```
 
-3. **Transfer UpgradeCap object** over to a multisig:
+3. Transfer `UpgradeCap` object over to a multisig:
 ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
 ```
 
-4. **Check new owner** of AdminCap object 
+4. Check new owner of `AdminCap` object:
 ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'


### PR DESCRIPTION
### Description

This pull request updates documentation in several files to improve clarity and consistency when describing the process of transferring Wormhole's NTT ownership to a multisig. The main changes involve standardizing the formatting for object names and step descriptions.

Documentation improvements:

* Updated step descriptions to consistently use backticks for object names (`AdminCap`, `UpgradeCap`) and removed bold formatting for clarity in `llms-files/llms-ntt.txt`, `llms-files/llms-transfer.txt`, `llms-full.txt`, and `products/token-transfers/native-token-transfers/faqs.md`. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL6895-R6905) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L13060-R13070) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L17801-R17811) [[4]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddL43-R53)
* Clarified instructions for checking the new owner by explicitly referencing the `AdminCap` object in all relevant documentation files. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL6895-R6905) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L13060-R13070) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L17801-R17811) [[4]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddL43-R53)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
