### PR TITLE
Ilariae/ntt vs wtt 

### DIFF
--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -138,24 +138,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -3679,24 +3679,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -2171,24 +2171,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -1216,24 +1216,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -166,7 +166,7 @@ Wormhole provides two distinct mechanisms for transferring assets cross-chain: [
 | **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
 | **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
 | **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintains the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, creates a new wrapped version on the destination chain  |
 | **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
 | **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -147,27 +147,37 @@ At a high level, the flow looks like this:
 
 ```mermaid
 flowchart LR
-    A[User] --> B[Source chain\nWormhole contract]
-    B --> C[Guardians\nsign VAA]
-    C --> D[Destination chain\nWormhole contract]
-    D -->|NTT| E[Mint or release\nnative tokens]
-    D -->|WTT| F[Mint wrapped\ntokens]
+    A[User] --> B[Source chain<br/>Wormhole contract]
+    B --> C[Guardians<br/>sign VAA]
+    C --> D[Destination chain<br/>Wormhole contract]
+    D -->|NTT| E[Mint or release<br/>native tokens]
+    D -->|WTT| F[Mint wrapped<br/>tokens]
     E --> G[Recipient]
     F --> G[Recipient]
 ```
 
 ## Choosing Between NTT and WTT
 
-| Feature                  | NTT (Native Token Transfers)                                        | WTT (Wrapped Token Transfers)                                 |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Token Representation** | Maintains the same token across chains                              | Creates a new wrapped version on the destination chain        |
-| **Contract Ownership**   | Requires projects to deploy and manage their own transfer contracts | Contracts are owned and managed by Wormhole                   |
-| **Setup Effort**         | Higher (deploy contracts, configure relayers)                       | Lower (no custom contracts required)                          |
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
+
+| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity, and projects that want full control of their cross-chain token | Consumer apps, games, wrapped-token use cases, and projects that want a fast, managed bridging solution |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
-| **Best For**             | Projects that want full control of their cross-chain token          | Projects that want a fast, managed bridging solution          |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
 
 !!! note "Terminology"
     In the SDK and smart contracts, Wrapped Token Transfers (WTT) are referred to as Token Bridge. In documentation, we use WTT for clarity. Both terms describe the same protocol.
+
+In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+
 
 ## Next Steps
 
@@ -8428,24 +8438,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -934,24 +934,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -685,24 +685,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -633,24 +633,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -257,24 +257,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 
@@ -498,27 +481,37 @@ At a high level, the flow looks like this:
 
 ```mermaid
 flowchart LR
-    A[User] --> B[Source chain\nWormhole contract]
-    B --> C[Guardians\nsign VAA]
-    C --> D[Destination chain\nWormhole contract]
-    D -->|NTT| E[Mint or release\nnative tokens]
-    D -->|WTT| F[Mint wrapped\ntokens]
+    A[User] --> B[Source chain<br/>Wormhole contract]
+    B --> C[Guardians<br/>sign VAA]
+    C --> D[Destination chain<br/>Wormhole contract]
+    D -->|NTT| E[Mint or release<br/>native tokens]
+    D -->|WTT| F[Mint wrapped<br/>tokens]
     E --> G[Recipient]
     F --> G[Recipient]
 ```
 
 ## Choosing Between NTT and WTT
 
-| Feature                  | NTT (Native Token Transfers)                                        | WTT (Wrapped Token Transfers)                                 |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Token Representation** | Maintains the same token across chains                              | Creates a new wrapped version on the destination chain        |
-| **Contract Ownership**   | Requires projects to deploy and manage their own transfer contracts | Contracts are owned and managed by Wormhole                   |
-| **Setup Effort**         | Higher (deploy contracts, configure relayers)                       | Lower (no custom contracts required)                          |
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
+
+| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity, and projects that want full control of their cross-chain token | Consumer apps, games, wrapped-token use cases, and projects that want a fast, managed bridging solution |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
-| **Best For**             | Projects that want full control of their cross-chain token          | Projects that want a fast, managed bridging solution          |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
 
 !!! note "Terminology"
     In the SDK and smart contracts, Wrapped Token Transfers (WTT) are referred to as Token Bridge. In documentation, we use WTT for clarity. Both terms describe the same protocol.
+
+In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+
 
 ## Next Steps
 
@@ -16458,24 +16451,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -500,7 +500,7 @@ Wormhole provides two distinct mechanisms for transferring assets cross-chain: [
 | **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
 | **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
 | **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintains the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, creates a new wrapped version on the destination chain  |
 | **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
 | **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -4830,24 +4830,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -57,27 +57,37 @@ At a high level, the flow looks like this:
 
 ```mermaid
 flowchart LR
-    A[User] --> B[Source chain\nWormhole contract]
-    B --> C[Guardians\nsign VAA]
-    C --> D[Destination chain\nWormhole contract]
-    D -->|NTT| E[Mint or release\nnative tokens]
-    D -->|WTT| F[Mint wrapped\ntokens]
+    A[User] --> B[Source chain<br/>Wormhole contract]
+    B --> C[Guardians<br/>sign VAA]
+    C --> D[Destination chain<br/>Wormhole contract]
+    D -->|NTT| E[Mint or release<br/>native tokens]
+    D -->|WTT| F[Mint wrapped<br/>tokens]
     E --> G[Recipient]
     F --> G[Recipient]
 ```
 
 ## Choosing Between NTT and WTT
 
-| Feature                  | NTT (Native Token Transfers)                                        | WTT (Wrapped Token Transfers)                                 |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Token Representation** | Maintains the same token across chains                              | Creates a new wrapped version on the destination chain        |
-| **Contract Ownership**   | Requires projects to deploy and manage their own transfer contracts | Contracts are owned and managed by Wormhole                   |
-| **Setup Effort**         | Higher (deploy contracts, configure relayers)                       | Lower (no custom contracts required)                          |
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
+
+| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity, and projects that want full control of their cross-chain token | Consumer apps, games, wrapped-token use cases, and projects that want a fast, managed bridging solution |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
-| **Best For**             | Projects that want full control of their cross-chain token          | Projects that want a fast, managed bridging solution          |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
 
 !!! note "Terminology"
     In the SDK and smart contracts, Wrapped Token Transfers (WTT) are referred to as Token Bridge. In documentation, we use WTT for clarity. Both terms describe the same protocol.
+
+In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+
 
 ## Next Steps
 
@@ -3722,24 +3732,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -76,7 +76,7 @@ Wormhole provides two distinct mechanisms for transferring assets cross-chain: [
 | **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
 | **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
 | **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintains the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, creates a new wrapped version on the destination chain  |
 | **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
 | **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25403,7 +25403,7 @@ Wormhole provides two distinct mechanisms for transferring assets cross-chain: [
 | **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
 | **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
 | **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintains the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, creates a new wrapped version on the destination chain  |
 | **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
 | **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14908,24 +14908,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 
@@ -25397,27 +25380,37 @@ At a high level, the flow looks like this:
 
 ```mermaid
 flowchart LR
-    A[User] --> B[Source chain\nWormhole contract]
-    B --> C[Guardians\nsign VAA]
-    C --> D[Destination chain\nWormhole contract]
-    D -->|NTT| E[Mint or release\nnative tokens]
-    D -->|WTT| F[Mint wrapped\ntokens]
+    A[User] --> B[Source chain<br/>Wormhole contract]
+    B --> C[Guardians<br/>sign VAA]
+    C --> D[Destination chain<br/>Wormhole contract]
+    D -->|NTT| E[Mint or release<br/>native tokens]
+    D -->|WTT| F[Mint wrapped<br/>tokens]
     E --> G[Recipient]
     F --> G[Recipient]
 ```
 
 ## Choosing Between NTT and WTT
 
-| Feature                  | NTT (Native Token Transfers)                                        | WTT (Wrapped Token Transfers)                                 |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Token Representation** | Maintains the same token across chains                              | Creates a new wrapped version on the destination chain        |
-| **Contract Ownership**   | Requires projects to deploy and manage their own transfer contracts | Contracts are owned and managed by Wormhole                   |
-| **Setup Effort**         | Higher (deploy contracts, configure relayers)                       | Lower (no custom contracts required)                          |
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
+
+| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity, and projects that want full control of their cross-chain token | Consumer apps, games, wrapped-token use cases, and projects that want a fast, managed bridging solution |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
-| **Best For**             | Projects that want full control of their cross-chain token          | Projects that want a fast, managed bridging solution          |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
 
 !!! note "Terminology"
     In the SDK and smart contracts, Wrapped Token Transfers (WTT) are referred to as Token Bridge. In documentation, we use WTT for clarity. Both terms describe the same protocol.
+
+In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+
 
 ## Next Steps
 

--- a/products/overview.md
+++ b/products/overview.md
@@ -40,24 +40,7 @@ Wormhole offers different solutions for cross-chain asset transfer, each designe
 
 </div>
 
-## Choose a Transfer Mechanism
-
-Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
-
-| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
-|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
-| **Best for**           | DeFi governance, native assets with multichain liquidity                   | Consumer apps, games, wrapped-token use cases |
-| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
-| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
-| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance       | Wrapped asset contract owned by the Wormhole WTT contract, upgradeable via a 13/19 Guardian governance process. |
-| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
-| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
-
-
-In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
-
-<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+For a deeper dive into how token transfers work and the differences between NTT and WTT, see the [Token Transfers Overview](/docs/products/token-transfers/overview/){target=\_blank}.
 
 Beyond asset transfers, Wormhole provides additional tools for cross-chain data and governance.
 

--- a/products/token-transfers/overview.md
+++ b/products/token-transfers/overview.md
@@ -34,16 +34,26 @@ flowchart LR
 
 ## Choosing Between NTT and WTT
 
-| Feature                  | NTT (Native Token Transfers)                                        | WTT (Wrapped Token Transfers)                                 |
-| ------------------------ | ------------------------------------------------------------------- | ------------------------------------------------------------- |
-| **Token Representation** | Maintains the same token across chains                              | Creates a new wrapped version on the destination chain        |
-| **Contract Ownership**   | Requires projects to deploy and manage their own transfer contracts | Contracts are owned and managed by Wormhole                   |
-| **Setup Effort**         | Higher (deploy contracts, configure relayers)                       | Lower (no custom contracts required)                          |
+Wormhole provides two distinct mechanisms for transferring assets cross-chain: [Native Token Transfers (NTT)](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank} and [Wrapped Token Transfers (WTT)](/docs/products/token-transfers/wrapped-token-transfers/overview/){target=\_blank}. Both options offer distinct integration paths and feature sets tailored to your requirements, as outlined below.
+
+| Feature                | Native Token Transfers                                                     | Wrapped Token Transfers                                  |
+|------------------------|----------------------------------------------------------------------------|-----------------------------------------------|
+| **Best for**           | DeFi governance, native assets with multichain liquidity, and projects that want full control of their cross-chain token | Consumer apps, games, wrapped-token use cases, and projects that want a fast, managed bridging solution |
+| **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
+| **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
+| **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
-| **Best For**             | Projects that want full control of their cross-chain token          | Projects that want a fast, managed bridging solution          |
+| **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |
 
 !!! note "Terminology"
     In the SDK and smart contracts, Wrapped Token Transfers (WTT) are referred to as Token Bridge. In documentation, we use WTT for clarity. Both terms describe the same protocol.
+
+In the following video, Wormhole Foundation DevRel Pauline Barnades walks you through the key differences between Wormhole’s Native Token Transfers (NTT) and Wrapped Token Transfers (WTT) and how to select the best option for your use case:
+
+<style>.embed-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; } .embed-container iframe, .embed-container object, .embed-container embed { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }</style><div class='embed-container'><iframe src='https://www.youtube.com/embed/wKDf3dyH0OM?si=Gr_iMB1jSs_5Pokm' frameborder='0' allowfullscreen></iframe></div>
+
 
 ## Next Steps
 

--- a/products/token-transfers/overview.md
+++ b/products/token-transfers/overview.md
@@ -42,7 +42,7 @@ Wormhole provides two distinct mechanisms for transferring assets cross-chain: [
 | **Mechanism**          | Burn-and-mint or hub-and-spoke                                             | Lock-and-mint                                 |
 | **Security**           | Configurable rate limiting, pausing, access control, threshold attestations. Integrated Global Accountant | Preconfigured rate limiting and integrated Global Accountant |
 | **Contract Ownership** | User retains ownership and upgrade authority on each chain                 | Managed via Wormhole Governance |
-| **Token Contracts**    | Native contracts owned by your protocol governance, maintain the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, create a new wrapped version on the destination chain  |
+| **Token Contracts**    | Native contracts owned by your protocol governance, maintains the same token across chains       | Wrapped asset contract owned by the Wormhole WTT contract, creates a new wrapped version on the destination chain  |
 | **Integration**        | Customizable, flexible framework for advanced deployments                  | Straightforward, permissionless deployment    |
 | **User Experience**      | Seamless, users interact with the same token everywhere            | Wrapped assets may need explorer metadata updates for clarity |
 | **Examples**           | [NTT Connect](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}, [NTT TypeScript SDK](https://github.com/wormhole-foundation/demo-ntt-ts-sdk){target=\_blank}   | [Portal Bridge UI](https://portalbridge.com/){target=\_blank} |

--- a/products/token-transfers/overview.md
+++ b/products/token-transfers/overview.md
@@ -23,11 +23,11 @@ At a high level, the flow looks like this:
 
 ```mermaid
 flowchart LR
-    A[User] --> B[Source chain\nWormhole contract]
-    B --> C[Guardians\nsign VAA]
-    C --> D[Destination chain\nWormhole contract]
-    D -->|NTT| E[Mint or release\nnative tokens]
-    D -->|WTT| F[Mint wrapped\ntokens]
+    A[User] --> B[Source chain<br/>Wormhole contract]
+    B --> C[Guardians<br/>sign VAA]
+    C --> D[Destination chain<br/>Wormhole contract]
+    D -->|NTT| E[Mint or release<br/>native tokens]
+    D -->|WTT| F[Mint wrapped<br/>tokens]
     E --> G[Recipient]
     F --> G[Recipient]
 ```


### PR DESCRIPTION
### Description

This pull request reorganizes and clarifies documentation about Wormhole's cross-chain asset transfer mechanisms, specifically Native Token Transfers (NTT) and Wrapped Token Transfers (WTT). The main changes involve moving the detailed comparison table and explanatory video from the general overview to the dedicated token transfers overview, improving the logical flow and discoverability for users seeking in-depth information.

also fixes a mermaid diagram newline situation that wasn't displaying properly 

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
