### PR TITLE
Martinh/setpeer

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -81,7 +81,7 @@ Here's a breakdown of the key steps involved when deploying NTT:
 - **Choose deployment tool**: Use the [NTT Launchpad](https://ntt.wormhole.com/){target=\_blank} (for EVM chains only) or the [NTT CLI](/docs/products/token-transfers/native-token-transfers/reference/cli-commands/){target=\_blank}.
 - **Initialization**: Specify target chains and token details, and set up your CLI environment if using it.
 - **Deploy contracts**: Deploy NTT Manager contracts to all selected chains, confirming transactions and covering gas fees.
-- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections, and assign administrative roles.
+- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections (bilateral via [`setPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#setpeer){target=\_blank} / [`set_peer`](/docs/products/token-transfers/native-token-transfers/reference/manager/solana/#set_peer){target=\_blank}; local configuration, no cross-chain message), and assign administrative roles.
 - **Monitor and maintain**: Verify deployment, monitor total supply with the [Global Accountant](/docs/products/token-transfers/native-token-transfers/concepts/security/#global-accountant){target=\_blank}, and adjust configurations as needed.
 
 ## Use Cases 
@@ -1708,7 +1708,11 @@ function setOutboundLimit(uint256 limit) external
 
 ### setPeer
 
-Set peer contract information for a specific chain. *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+Set peer contract information for a specific chain; this is local manager configuration (no cross-chain message) and must be called on both chains. If either side is unset or mismatched, inbound verification or amount trimming fails ([`InvalidPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeer), [`InvalidPeerDecimals`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeerdecimals)). *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B as a peer with B’s manager address (`peerContract`), B’s token decimals (`decimals`), and the inbound limit from B → A (`inboundLimit`).
+    - **On Chain B**: Register Chain A the same way (A’s manager, A’s token decimals, inbound limit from A → B).
 
 ```sol
 function setPeer(
@@ -3612,7 +3616,11 @@ pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()>
 
 ### set_peer
 
-Sets a peer NTT Manager on another chain. *(Defined in example-native-token-transfers)*
+Sets a peer NTT Manager on another chain; this is local program configuration (no cross-chain message) and must be executed on both chains. If either side is unset or mismatched, messages from that peer will fail verification on receive. *(Defined in example-native-token-transfers)*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B with B’s manager address (address); this creates/updates the peer account (PDA "peer") and the inbound rate-limit account for B.
+    - **On Chain B**: Register Chain A the same way.
 
 ```rust
 pub fn set_peer(ctx: Context<SetPeer>, args: SetPeerArgs) -> Result<()>

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -415,7 +415,7 @@ Here's a breakdown of the key steps involved when deploying NTT:
 - **Choose deployment tool**: Use the [NTT Launchpad](https://ntt.wormhole.com/){target=\_blank} (for EVM chains only) or the [NTT CLI](/docs/products/token-transfers/native-token-transfers/reference/cli-commands/){target=\_blank}.
 - **Initialization**: Specify target chains and token details, and set up your CLI environment if using it.
 - **Deploy contracts**: Deploy NTT Manager contracts to all selected chains, confirming transactions and covering gas fees.
-- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections, and assign administrative roles.
+- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections (bilateral via [`setPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#setpeer){target=\_blank} / [`set_peer`](/docs/products/token-transfers/native-token-transfers/reference/manager/solana/#set_peer){target=\_blank}; local configuration, no cross-chain message), and assign administrative roles.
 - **Monitor and maintain**: Verify deployment, monitor total supply with the [Global Accountant](/docs/products/token-transfers/native-token-transfers/concepts/security/#global-accountant){target=\_blank}, and adjust configurations as needed.
 
 ## Use Cases 
@@ -2876,7 +2876,11 @@ function setOutboundLimit(uint256 limit) external
 
 ### setPeer
 
-Set peer contract information for a specific chain. *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+Set peer contract information for a specific chain; this is local manager configuration (no cross-chain message) and must be called on both chains. If either side is unset or mismatched, inbound verification or amount trimming fails ([`InvalidPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeer), [`InvalidPeerDecimals`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeerdecimals)). *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B as a peer with B’s manager address (`peerContract`), B’s token decimals (`decimals`), and the inbound limit from B → A (`inboundLimit`).
+    - **On Chain B**: Register Chain A the same way (A’s manager, A’s token decimals, inbound limit from A → B).
 
 ```sol
 function setPeer(
@@ -4780,7 +4784,11 @@ pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()>
 
 ### set_peer
 
-Sets a peer NTT Manager on another chain. *(Defined in example-native-token-transfers)*
+Sets a peer NTT Manager on another chain; this is local program configuration (no cross-chain message) and must be executed on both chains. If either side is unset or mismatched, messages from that peer will fail verification on receive. *(Defined in example-native-token-transfers)*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B with B’s manager address (address); this creates/updates the peer account (PDA "peer") and the inbound rate-limit account for B.
+    - **On Chain B**: Register Chain A the same way.
 
 ```rust
 pub fn set_peer(ctx: Context<SetPeer>, args: SetPeerArgs) -> Result<()>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19441,7 +19441,7 @@ Here's a breakdown of the key steps involved when deploying NTT:
 - **Choose deployment tool**: Use the [NTT Launchpad](https://ntt.wormhole.com/){target=\_blank} (for EVM chains only) or the [NTT CLI](/docs/products/token-transfers/native-token-transfers/reference/cli-commands/){target=\_blank}.
 - **Initialization**: Specify target chains and token details, and set up your CLI environment if using it.
 - **Deploy contracts**: Deploy NTT Manager contracts to all selected chains, confirming transactions and covering gas fees.
-- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections, and assign administrative roles.
+- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections (bilateral via [`setPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#setpeer){target=\_blank} / [`set_peer`](/docs/products/token-transfers/native-token-transfers/reference/manager/solana/#set_peer){target=\_blank}; local configuration, no cross-chain message), and assign administrative roles.
 - **Monitor and maintain**: Verify deployment, monitor total supply with the [Global Accountant](/docs/products/token-transfers/native-token-transfers/concepts/security/#global-accountant){target=\_blank}, and adjust configurations as needed.
 
 ## Use Cases 
@@ -20787,7 +20787,11 @@ function setOutboundLimit(uint256 limit) external
 
 ### setPeer
 
-Set peer contract information for a specific chain. *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+Set peer contract information for a specific chain; this is local manager configuration (no cross-chain message) and must be called on both chains. If either side is unset or mismatched, inbound verification or amount trimming fails ([`InvalidPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeer), [`InvalidPeerDecimals`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeerdecimals)). *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B as a peer with B’s manager address (`peerContract`), B’s token decimals (`decimals`), and the inbound limit from B → A (`inboundLimit`).
+    - **On Chain B**: Register Chain A the same way (A’s manager, A’s token decimals, inbound limit from A → B).
 
 ```sol
 function setPeer(
@@ -22691,7 +22695,11 @@ pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()>
 
 ### set_peer
 
-Sets a peer NTT Manager on another chain. *(Defined in example-native-token-transfers)*
+Sets a peer NTT Manager on another chain; this is local program configuration (no cross-chain message) and must be executed on both chains. If either side is unset or mismatched, messages from that peer will fail verification on receive. *(Defined in example-native-token-transfers)*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B with B’s manager address (address); this creates/updates the peer account (PDA "peer") and the inbound rate-limit account for B.
+    - **On Chain B**: Register Chain A the same way.
 
 ```rust
 pub fn set_peer(ctx: Context<SetPeer>, args: SetPeerArgs) -> Result<()>

--- a/products/token-transfers/native-token-transfers/overview.md
+++ b/products/token-transfers/native-token-transfers/overview.md
@@ -40,7 +40,7 @@ Here's a breakdown of the key steps involved when deploying NTT:
 - **Choose deployment tool**: Use the [NTT Launchpad](https://ntt.wormhole.com/){target=\_blank} (for EVM chains only) or the [NTT CLI](/docs/products/token-transfers/native-token-transfers/reference/cli-commands/){target=\_blank}.
 - **Initialization**: Specify target chains and token details, and set up your CLI environment if using it.
 - **Deploy contracts**: Deploy NTT Manager contracts to all selected chains, confirming transactions and covering gas fees.
-- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections, and assign administrative roles.
+- **Finalize configurations**: Grant minting authority, configure rate limits, establish peer manager connections (bilateral via [`setPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#setpeer){target=\_blank} / [`set_peer`](/docs/products/token-transfers/native-token-transfers/reference/manager/solana/#set_peer){target=\_blank}; local configuration, no cross-chain message), and assign administrative roles.
 - **Monitor and maintain**: Verify deployment, monitor total supply with the [Global Accountant](/docs/products/token-transfers/native-token-transfers/concepts/security/#global-accountant){target=\_blank}, and adjust configurations as needed.
 
 ## Use Cases 

--- a/products/token-transfers/native-token-transfers/reference/manager/evm.md
+++ b/products/token-transfers/native-token-transfers/reference/manager/evm.md
@@ -1229,7 +1229,11 @@ function setOutboundLimit(uint256 limit) external
 
 ### setPeer
 
-Set peer contract information for a specific chain. *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+Set peer contract information for a specific chain; this is local manager configuration (no cross-chain message) and must be called on both chains. If either side is unset or mismatched, inbound verification or amount trimming fails ([`InvalidPeer`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeer), [`InvalidPeerDecimals`](/docs/products/token-transfers/native-token-transfers/reference/manager/evm/#invalidpeerdecimals)). *(Defined in [NttManager.sol](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/NttManager/NttManager.sol){target=\_blank})*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B as a peer with B’s manager address (`peerContract`), B’s token decimals (`decimals`), and the inbound limit from B → A (`inboundLimit`).
+    - **On Chain B**: Register Chain A the same way (A’s manager, A’s token decimals, inbound limit from A → B).
 
 ```sol
 function setPeer(

--- a/products/token-transfers/native-token-transfers/reference/manager/solana.md
+++ b/products/token-transfers/native-token-transfers/reference/manager/solana.md
@@ -959,7 +959,11 @@ pub fn set_paused(ctx: Context<SetPaused>, pause: bool) -> Result<()>
 
 ### set_peer
 
-Sets a peer NTT Manager on another chain. *(Defined in example-native-token-transfers)*
+Sets a peer NTT Manager on another chain; this is local program configuration (no cross-chain message) and must be executed on both chains. If either side is unset or mismatched, messages from that peer will fail verification on receive. *(Defined in example-native-token-transfers)*
+
+!!! tip "Example"
+    - **On Chain A**: Register Chain B with B’s manager address (address); this creates/updates the peer account (PDA "peer") and the inbound rate-limit account for B.
+    - **On Chain B**: Register Chain A the same way.
 
 ```rust
 pub fn set_peer(ctx: Context<SetPeer>, args: SetPeerArgs) -> Result<()>


### PR DESCRIPTION
### Description

This pull request updates deployment and configuration documentation for Native Token Transfers (NTT) across EVM and Solana chains. The main focus is clarifying the requirements and procedures for establishing peer manager connections, emphasizing that peer registration is a bilateral, local configuration step that must be performed on both chains, and that mismatches will cause verification failures. Example usage and error scenarios are now included for both EVM and Solana implementations.

**Deployment and Configuration Steps**

* Updated deployment guides in `llms-files/llms-ntt.txt`, `llms-files/llms-transfer.txt`, `llms-full.txt`, and `products/token-transfers/native-token-transfers/overview.md` to clarify that peer manager connections must be set up bilaterally using `setPeer` (EVM) or `set_peer` (Solana), and that this is a local configuration without cross-chain messages. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL84-R84) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L418-R418) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L19444-R19444) [[4]](diffhunk://#diff-a62ec1aacc819708b104cce63d70361c4bd08b0a912c1c6a6509544746286af1L43-R43)

**EVM Implementation Details**

* Expanded documentation for the `setPeer` function in `llms-files/llms-ntt.txt`, `llms-files/llms-transfer.txt`, `llms-full.txt`, and `products/token-transfers/native-token-transfers/reference/manager/evm.md` to explain bilateral setup, local configuration, and the consequences of unset or mismatched peers (including specific error references). Added detailed example usage. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL1711-R1715) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L2879-R2883) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L20790-R20794) [[4]](diffhunk://#diff-ff4a5f2ac041059528b57da708d12b349fcbff1802af924eb1a2052c2cf9ffd6L1232-R1236)

**Solana Implementation Details**

* Expanded documentation for the `set_peer` function in `llms-files/llms-ntt.txt`, `llms-files/llms-transfer.txt`, `llms-full.txt`, and `products/token-transfers/native-token-transfers/reference/manager/solana.md` to clarify that peer setup is local and must be performed on both chains, with mismatches causing message verification failures. Added example usage for the setup process. [[1]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebL3615-R3623) [[2]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54L4783-R4791) [[3]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L22694-R22702) [[4]](diffhunk://#diff-34fcf1f783f50c1874a5251aa1b6b13ad3259ed559d7d76c558a8080c485f51eL962-R966)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
