### PR TITLE
Martinh/governance contracts

### DIFF
--- a/.snippets/text/products/reference/contract-addresses/governance.md
+++ b/.snippets/text/products/reference/contract-addresses/governance.md
@@ -1,0 +1,13 @@
+=== "Mainnet"
+
+    <table data-full-width="true" markdown><thead><th>Chain Name</th><th>Chain ID</th><th>Contract Address</th></thead><tbody>
+    <tr><td>Solana</td><td><code>1</code></td><td><code>NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm</code></td></tr>
+    <tr><td>Ethereum</td><td><code>2</code></td><td><code>0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf</code></td></tr>
+    <tr><td>Arbitrum</td><td><code>23</code></td><td><code>0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F</code></td></tr>
+    <tr><td>Avalanche</td><td><code>6</code></td><td><code>0x169D91C797edF56100F1B765268145660503a423</code></td></tr>
+    <tr><td>Base</td><td><code>30</code></td><td><code>0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1</code></td></tr>
+    <tr><td>HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }</td><td><code>47</code></td><td><code>0x574B7864119C9223A9870Ea614dC91A8EE09E512</code></td></tr>
+    <tr><td>Optimism</td><td><code>24</code></td><td><code>0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8</code></td></tr>
+    <tr><td>Unichain</td><td><code>44</code></td><td><code>0x574b7864119c9223a9870ea614dc91a8ee09e512</code></td></tr>
+    </tbody>
+    </table>

--- a/.snippets/text/products/reference/contract-addresses/governance.md
+++ b/.snippets/text/products/reference/contract-addresses/governance.md
@@ -1,13 +1,13 @@
 === "Mainnet"
 
-    <table data-full-width="true" markdown><thead><th>Chain Name</th><th>Chain ID</th><th>Contract Address</th></thead><tbody>
-    <tr><td>Solana</td><td><code>1</code></td><td><code>NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm</code></td></tr>
-    <tr><td>Ethereum</td><td><code>2</code></td><td><code>0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf</code></td></tr>
-    <tr><td>Arbitrum</td><td><code>23</code></td><td><code>0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F</code></td></tr>
-    <tr><td>Avalanche</td><td><code>6</code></td><td><code>0x169D91C797edF56100F1B765268145660503a423</code></td></tr>
-    <tr><td>Base</td><td><code>30</code></td><td><code>0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1</code></td></tr>
-    <tr><td>HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }</td><td><code>47</code></td><td><code>0x574B7864119C9223A9870Ea614dC91A8EE09E512</code></td></tr>
-    <tr><td>Optimism</td><td><code>24</code></td><td><code>0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8</code></td></tr>
-    <tr><td>Unichain</td><td><code>44</code></td><td><code>0x574b7864119c9223a9870ea614dc91a8ee09e512</code></td></tr>
+    <table data-full-width="true" markdown><thead><th>Chain Name</th><th>Contract Address</th></thead><tbody>
+    <tr><td>Solana</td><td><code>NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm</code></td></tr>
+    <tr><td>Ethereum</td><td><code>0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf</code></td></tr>
+    <tr><td>Arbitrum</td><td><code>0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F</code></td></tr>
+    <tr><td>Avalanche</td><td><code>0x169D91C797edF56100F1B765268145660503a423</code></td></tr>
+    <tr><td>Base</td><td><code>0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1</code></td></tr>
+    <tr><td>HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }</td><td><code>0x574B7864119C9223A9870Ea614dC91A8EE09E512</code></td></tr>
+    <tr><td>Optimism</td><td><code>0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8</code></td></tr>
+    <tr><td>Unichain</td><td><code>0x574b7864119c9223a9870ea614dc91a8ee09e512</code></td></tr>
     </tbody>
     </table>

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -11988,14 +11988,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -11984,6 +11984,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -10476,6 +10476,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -10480,14 +10480,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -9525,14 +9525,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -9521,6 +9521,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -16747,6 +16747,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -16751,14 +16751,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -9243,14 +9243,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -9239,6 +9239,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-reference.txt
+++ b/llms-files/llms-reference.txt
@@ -2723,6 +2723,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-reference.txt
+++ b/llms-files/llms-reference.txt
@@ -2727,14 +2727,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -8994,14 +8994,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -8990,6 +8990,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -8942,14 +8942,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -8938,6 +8938,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -24760,6 +24760,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -24764,14 +24764,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -13139,14 +13139,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -13135,6 +13135,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -12037,6 +12037,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -12041,14 +12041,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16165,14 +16165,14 @@ categories: Reference
 
 === "Mainnet"
 
-    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
-| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
-| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
-| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
-| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
-| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
-| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
-| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+    | Solana | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16161,6 +16161,22 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+=== "Mainnet"
+
+    | Solana | 1 | NGoD1yTeq5KaURrZo7MnCTFzTA4g62ygakJCnzMLCfm |
+| Ethereum | 2 | 0x23Fea5514DFC9821479fBE18BA1D7e1A61f6FfCf |
+| Arbitrum | 23 | 0x36CF4c88FA548c6Ad9fcDc696e1c27Bb3306163F |
+| Avalanche | 6 | 0x169D91C797edF56100F1B765268145660503a423 |
+| Base | 30 | 0x838a95B6a3E06B6f11C437e22f3C7561a6ec40F1 |
+| HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 47 | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
+| Optimism | 24 | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
+| Unichain | 44 | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 

--- a/products/reference/contract-addresses.md
+++ b/products/reference/contract-addresses.md
@@ -32,6 +32,13 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Solana</td><td><code>tD8RmtdcV7bzBeuFgyrFc8wvayj988ChccEzRQzo6md</code></td></tr><tr><td>Arbitrum Sepolia</td><td><code>0xe0418C44F06B0b0D7D1706E01706316DBB0B210E</code></td></tr><tr><td>Optimism Sepolia</td><td><code>0x6BAa7397c18abe6221b4f6C3Ac91C88a9faE00D8</code></td></tr></tbody></table>
     
+## Guardian Governance
+
+--8<-- 'text/products/reference/contract-addresses/governance.md'
+
+!!! note
+    Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.
+
 
 ## Read-Only Deployments
 


### PR DESCRIPTION
### Description

This pull request adds comprehensive documentation for Guardian Governance contract addresses across multiple chains in both the main reference markdown and all related LLMS reference files. It introduces a new section listing contract addresses for Guardian-governed ownership contracts on various mainnets, along with an explanatory note about their purpose and trust model.

Guardian Governance contract documentation:

* Added a new "Guardian Governance" section to `.snippets/text/products/reference/contract-addresses/governance.md`, listing contract addresses for Solana, Ethereum, Arbitrum, Avalanche, Base, HyperEVM, Optimism, and Unichain mainnets.

Explanatory note and external references:

* Included a note explaining the Guardian-governed ownership contract model, emphasizing its trust assumptions and linking to EVM and SVM implementation details. [[1]](diffhunk://#diff-bd6ba7a8ca09d249155374fce471eb55c4fc5bfd33ef562ea9a0adfe6b075054R1-R13) [[2]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R16164-R16179) [[3]](diffhunk://#diff-2fd658d181dea4a290e267ee3a5335cda493799476553ba70b303f4312778649R2726-R2741) [[4]](diffhunk://#diff-bdc4a3fd4bc3b7983bdacfadf03530074922a9849f935b01a1d542587a082528R11987-R12002) [[5]](diffhunk://#diff-6c27d13b13970bc40f4abe2ac59f12147345db67dc1c40657f0ad253a45f62d6R10479-R10494) [[6]](diffhunk://#diff-e76d7844fb1a3547c6b5e844603a72f8c088598817b2224beada8977e63f5046R9524-R9539) [[7]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebR16750-R16765) [[8]](diffhunk://#diff-00968f1b61a240b3f6e5a87f36aa2e6a78394870767331e408f13370140c8e75R9242-R9257) [[9]](diffhunk://#diff-e18f162351bfaa8c42eb4b5166951ddb4457336bb773421566864af78a9322aaR8993-R9008) [[10]](diffhunk://#diff-2ea4158b6d3cca8b5d7ec2fe120854fb2286e81a7777ff8bcc843a7d5840725bR8941-R8956) [[11]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R24763-R24778) [[12]](diffhunk://#diff-2f5528ac89bcf8c877e1dde5e7be01d9fa0af43edd56d29664a8aa938c5e82d0R13138-R13153) [[13]](diffhunk://#diff-941bf7040efdb9c3b87f15207615ecf8ba303cc8b9a5605272ed4c1cd74e58d1R12040-R12055)

This update ensures consistent and discoverable documentation of Guardian Governance contracts for users and developers across all product and reference materials.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
