### PR TITLE
Martinh/update multigov link

### DIFF
--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -744,7 +744,7 @@ MultiGov is designed to be flexible but stable. Due to the system's complexity a
 - `HubVotePool`:
     - Can be replaced by setting a new `HubVotePool` on the `HubGovernor`.
     - Requires re-registering all spokes on the new `HubVotePool`.
-    - Must register the query type and implementation for vote decoding by calling `registerQueryType` on the new `HubVotePool`. <!-- put registerQueryType link back in once repo is public https://github.com/wormhole-foundation/example-multigov/blob/main/evm/src/HubVotePool.sol#L84 -->
+    - Must register the query type and implementation for vote decoding by calling [`registerQueryType`](https://github.com/wormhole-foundation/multigov/blob/main/evm/src/HubVotePool.sol#L87){target=\_blank} on the new `HubVotePool`.
     - A new proposal would have to authorize the governor to use the newly created hub vote pool and will also handle registering the appropriate query decoders and registering the appropriate spoke `SpokeVoteAggregators`.
 
 - `SpokeMessageExecutor`:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14425,7 +14425,7 @@ MultiGov is designed to be flexible but stable. Due to the system's complexity a
 - `HubVotePool`:
     - Can be replaced by setting a new `HubVotePool` on the `HubGovernor`.
     - Requires re-registering all spokes on the new `HubVotePool`.
-    - Must register the query type and implementation for vote decoding by calling `registerQueryType` on the new `HubVotePool`. <!-- put registerQueryType link back in once repo is public https://github.com/wormhole-foundation/example-multigov/blob/main/evm/src/HubVotePool.sol#L84 -->
+    - Must register the query type and implementation for vote decoding by calling [`registerQueryType`](https://github.com/wormhole-foundation/multigov/blob/main/evm/src/HubVotePool.sol#L87){target=\_blank} on the new `HubVotePool`.
     - A new proposal would have to authorize the governor to use the newly created hub vote pool and will also handle registering the appropriate query decoders and registering the appropriate spoke `SpokeVoteAggregators`.
 
 - `SpokeMessageExecutor`:

--- a/products/multigov/guides/upgrade-evm.md
+++ b/products/multigov/guides/upgrade-evm.md
@@ -16,7 +16,7 @@ MultiGov is designed to be flexible but stable. Due to the system's complexity a
 - `HubVotePool`:
     - Can be replaced by setting a new `HubVotePool` on the `HubGovernor`.
     - Requires re-registering all spokes on the new `HubVotePool`.
-    - Must register the query type and implementation for vote decoding by calling `registerQueryType` on the new `HubVotePool`. <!-- put registerQueryType link back in once repo is public https://github.com/wormhole-foundation/example-multigov/blob/main/evm/src/HubVotePool.sol#L84 -->
+    - Must register the query type and implementation for vote decoding by calling [`registerQueryType`](https://github.com/wormhole-foundation/multigov/blob/main/evm/src/HubVotePool.sol#L87){target=\_blank} on the new `HubVotePool`.
     - A new proposal would have to authorize the governor to use the newly created hub vote pool and will also handle registering the appropriate query decoders and registering the appropriate spoke `SpokeVoteAggregators`.
 
 - `SpokeMessageExecutor`:


### PR DESCRIPTION
### Description

This pull request updates documentation references for the `registerQueryType` method in the context of upgrading or configuring the `HubVotePool` in MultiGov. The main change is replacing a placeholder comment with a direct link to the actual implementation in the public repository, improving clarity and usability for developers.

Documentation improvements:

* Updated the description for registering the query type and implementation for vote decoding in the `HubVotePool` section to use a direct link to the public `registerQueryType` implementation in the MultiGov repository, replacing the previous placeholder comment. (`llms-files/llms-multigov.txt`, [llms-files/llms-multigov.txtL747-R747](diffhunk://#diff-e76d7844fb1a3547c6b5e844603a72f8c088598817b2224beada8977e63f5046L747-R747))  
* Made the same documentation update in the full reference file for consistency. (`llms-full.txt`, [llms-full.txtL14428-R14428](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714L14428-R14428))
* Applied the same update in the EVM upgrade guide to ensure all documentation points to the correct public resource. (`products/multigov/guides/upgrade-evm.md`, [products/multigov/guides/upgrade-evm.mdL19-R19](diffhunk://#diff-0403c05834b13db4fb38c044981eef1dc5b269a69f4fb1f463873fc6e892f73cL19-R19))

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
