### PR TITLE
add question to ntt faq about minting sui tokens after the treasury cap moved to the ntt manager

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -6930,26 +6930,27 @@ Transferring ownership of Wormhole's NTT to a multisig on Solana is a two-step p
 For a practical demonstration of transferring ownership of Wormhole's NTT to a multisig on Solana, visit the [GitHub demo](https://github.com/wormhole-foundation/demo-ntt-solana-multisig-tools){target=\_blank} providing scripts and guidance for managing an NTT program using Squads multisig functionality, including ownership transfer procedures.
 
 ## How can I transfer ownership of NTT to a multisig on Sui?
+
 1. Find out the `AdminCap` and `UpgradeCap` for your NTT manager with this command:
-```bash
+    ```bash
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
-```
+    ```
 
 2. Transfer `AdminCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
-```
+    ```
 
 3. Transfer `UpgradeCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
-```
+    ```
 
 4. Check new owner of `AdminCap` object:
-```bash
+    ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'
-```
+    ```
 
 ## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
 
@@ -6958,7 +6959,7 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 The flow works as follows:
 
 1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
-2. **Mint assets**: Perform your minting operations with the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap.
 3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -6957,9 +6957,9 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 
 The flow works as follows:
 
-1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
 2. **Mint assets**: Perform your minting operations with the treasury cap
-3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -6965,7 +6965,7 @@ The flow works as follows:
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
 
-We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+It is recommended to use [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
 
 ## How can I specify a custom RPC for NTT?
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -6951,6 +6951,21 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
         | jq -r '.owner'
 ```
 
+## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
+
+To mint tokens after moving the treasury object to the NTT manager on Sui, you need to use the `take_treasury_cap` function from the [NTT contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sui/packages/ntt/sources/state.move#L307C16-L307C33){target=\_blank}. This function allows the admin to temporarily take the treasury cap to mint assets.
+
+The flow works as follows:
+
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+
+!!!Important 
+    Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
+
+We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+
 ## How can I specify a custom RPC for NTT?
 
 To specify a custom RPC for Wormhole's NTT, create an `overrides.json` file in the root of your deployment directory. This file allows you to define custom RPC endpoints, which can be helpful when you need to connect to specific nodes or networks for better performance, security, or control over the RPC connection.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13145,9 +13145,9 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 
 The flow works as follows:
 
-1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
 2. **Mint assets**: Perform your minting operations with the treasury cap
-3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13139,6 +13139,21 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
         | jq -r '.owner'
 ```
 
+## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
+
+To mint tokens after moving the treasury object to the NTT manager on Sui, you need to use the `take_treasury_cap` function from the [NTT contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sui/packages/ntt/sources/state.move#L307C16-L307C33){target=\_blank}. This function allows the admin to temporarily take the treasury cap to mint assets.
+
+The flow works as follows:
+
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+
+!!!Important 
+    Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
+
+We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+
 ## How can I specify a custom RPC for NTT?
 
 To specify a custom RPC for Wormhole's NTT, create an `overrides.json` file in the root of your deployment directory. This file allows you to define custom RPC endpoints, which can be helpful when you need to connect to specific nodes or networks for better performance, security, or control over the RPC connection.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13153,7 +13153,7 @@ The flow works as follows:
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
 
-We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+It is recommended to use [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
 
 ## How can I specify a custom RPC for NTT?
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13118,26 +13118,27 @@ Transferring ownership of Wormhole's NTT to a multisig on Solana is a two-step p
 For a practical demonstration of transferring ownership of Wormhole's NTT to a multisig on Solana, visit the [GitHub demo](https://github.com/wormhole-foundation/demo-ntt-solana-multisig-tools){target=\_blank} providing scripts and guidance for managing an NTT program using Squads multisig functionality, including ownership transfer procedures.
 
 ## How can I transfer ownership of NTT to a multisig on Sui?
+
 1. Find out the `AdminCap` and `UpgradeCap` for your NTT manager with this command:
-```bash
+    ```bash
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
-```
+    ```
 
 2. Transfer `AdminCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
-```
+    ```
 
 3. Transfer `UpgradeCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
-```
+    ```
 
 4. Check new owner of `AdminCap` object:
-```bash
+    ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'
-```
+    ```
 
 ## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
 
@@ -13146,7 +13147,7 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 The flow works as follows:
 
 1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
-2. **Mint assets**: Perform your minting operations with the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap.
 3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17886,9 +17886,9 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 
 The flow works as follows:
 
-1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
 2. **Mint assets**: Perform your minting operations with the treasury cap
-3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17880,6 +17880,21 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
         | jq -r '.owner'
 ```
 
+## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
+
+To mint tokens after moving the treasury object to the NTT manager on Sui, you need to use the `take_treasury_cap` function from the [NTT contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sui/packages/ntt/sources/state.move#L307C16-L307C33){target=\_blank}. This function allows the admin to temporarily take the treasury cap to mint assets.
+
+The flow works as follows:
+
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+
+!!!Important 
+    Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
+
+We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+
 ## How can I specify a custom RPC for NTT?
 
 To specify a custom RPC for Wormhole's NTT, create an `overrides.json` file in the root of your deployment directory. This file allows you to define custom RPC endpoints, which can be helpful when you need to connect to specific nodes or networks for better performance, security, or control over the RPC connection.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17859,26 +17859,27 @@ Transferring ownership of Wormhole's NTT to a multisig on Solana is a two-step p
 For a practical demonstration of transferring ownership of Wormhole's NTT to a multisig on Solana, visit the [GitHub demo](https://github.com/wormhole-foundation/demo-ntt-solana-multisig-tools){target=\_blank} providing scripts and guidance for managing an NTT program using Squads multisig functionality, including ownership transfer procedures.
 
 ## How can I transfer ownership of NTT to a multisig on Sui?
+
 1. Find out the `AdminCap` and `UpgradeCap` for your NTT manager with this command:
-```bash
+    ```bash
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
-```
+    ```
 
 2. Transfer `AdminCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
-```
+    ```
 
 3. Transfer `UpgradeCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
-```
+    ```
 
 4. Check new owner of `AdminCap` object:
-```bash
+    ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'
-```
+    ```
 
 ## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
 
@@ -17887,7 +17888,7 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 The flow works as follows:
 
 1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
-2. **Mint assets**: Perform your minting operations with the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap.
 3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -17894,7 +17894,7 @@ The flow works as follows:
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
 
-We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+It is recommended to use [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
 
 ## How can I specify a custom RPC for NTT?
 

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -70,7 +70,7 @@ The flow works as follows:
 
 1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
 2. **Mint assets**: Perform your minting operations with the treasury cap
-3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -76,7 +76,7 @@ The flow works as follows:
 !!!Important 
     Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
 
-We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+It is recommended to use [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
 
 ## How can I specify a custom RPC for NTT?
 

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -68,7 +68,7 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 
 The flow works as follows:
 
-1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
 2. **Mint assets**: Perform your minting operations with the treasury cap
 3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
 

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -41,26 +41,27 @@ Transferring ownership of Wormhole's NTT to a multisig on Solana is a two-step p
 For a practical demonstration of transferring ownership of Wormhole's NTT to a multisig on Solana, visit the [GitHub demo](https://github.com/wormhole-foundation/demo-ntt-solana-multisig-tools){target=\_blank} providing scripts and guidance for managing an NTT program using Squads multisig functionality, including ownership transfer procedures.
 
 ## How can I transfer ownership of NTT to a multisig on Sui?
+
 1. Find out the `AdminCap` and `UpgradeCap` for your NTT manager with this command:
-```bash
+    ```bash
     sui client object $SUI_NTT_MANAGER_ADDRESS --json 2>/dev/null | jq -r '"AdminCap ID: \(.content.fields.admin_cap_id)\nUpgradeCap ID: \(.content.fields.upgrade_cap_id)"'
-```
+    ```
 
 2. Transfer `AdminCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id ADMIN_CAP_ID_STEP1
-```
+    ```
 
 3. Transfer `UpgradeCap` object over to a multisig:
-```bash
+    ```bash
     sui client transfer --to MULTISIG_ADDRESS --object-id UPGRADE_CAP_ID_STEP1
-```
+    ```
 
 4. Check new owner of `AdminCap` object:
-```bash
+    ```bash
     sui client object ADMIN_CAP_ID_STEP1 --json \
         | jq -r '.owner'
-```
+    ```
 
 ## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
 
@@ -69,7 +70,7 @@ To mint tokens after moving the treasury object to the NTT manager on Sui, you n
 The flow works as follows:
 
 1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap.
-2. **Mint assets**: Perform your minting operations with the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap.
 3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state.
 
 !!!Important 

--- a/products/token-transfers/native-token-transfers/faqs.md
+++ b/products/token-transfers/native-token-transfers/faqs.md
@@ -62,6 +62,21 @@ For a practical demonstration of transferring ownership of Wormhole's NTT to a m
         | jq -r '.owner'
 ```
 
+## How can I mint tokens after moving the treasury object to the NTT manager on Sui?
+
+To mint tokens after moving the treasury object to the NTT manager on Sui, you need to use the `take_treasury_cap` function from the [NTT contract](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sui/packages/ntt/sources/state.move#L307C16-L307C33){target=\_blank}. This function allows the admin to temporarily take the treasury cap to mint assets.
+
+The flow works as follows:
+
+1. **Take the treasury cap**: Use `state.take_treasury_cap(admin_cap)` to extract the treasury cap
+2. **Mint assets**: Perform your minting operations with the treasury cap
+3. **Return the treasury cap**: Use `state.return_treasury_cap(treasury_cap)` to return it to the state
+
+!!!Important 
+    Return the Treasury Cap! If the treasury cap is not returned in the same transaction, the NTT deployment will stop working. The contract will break and become non-functional.
+
+We recommend using [Programmable Transaction Blocks (PTBs)](https://docs.sui.io/concepts/transactions/prog-txn-blocks){target=\_blank} for this operation. PTBs allow you to execute multiple operations atomically in a single transaction, ensuring that both the minting operation and returning the treasury cap happen together, preventing any risk of the contract breaking.
+
 ## How can I specify a custom RPC for NTT?
 
 To specify a custom RPC for Wormhole's NTT, create an `overrides.json` file in the root of your deployment directory. This file allows you to define custom RPC endpoints, which can be helpful when you need to connect to specific nodes or networks for better performance, security, or control over the RPC connection.


### PR DESCRIPTION
### Description

This pull request adds new documentation and guidance for minting tokens after moving the treasury object to the NTT manager on Sui. The changes clarify the required steps and highlight the importance of returning the treasury cap in the same transaction to prevent contract failure. The updates are applied consistently across several files to improve user understanding and operational safety.

### Sui NTT Minting Flow Documentation

* Added a new FAQ section explaining how to mint tokens after transferring the treasury object to the NTT manager on Sui, including step-by-step instructions for using the `take_treasury_cap` and `return_treasury_cap` functions from the NTT contract. [[1]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddR66-R80) [[2]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebR6955-R6969) [[3]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R13143-R13157) [[4]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R17884-R17898)
* Emphasized the critical requirement to return the treasury cap within the same transaction to avoid breaking the contract, with a warning callout for users. [[1]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddR66-R80) [[2]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebR6955-R6969) [[3]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R13143-R13157) [[4]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R17884-R17898)
* Recommended using Programmable Transaction Blocks (PTBs) to atomically perform minting and treasury cap return operations, ensuring contract safety. [[1]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddR66-R80) [[2]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebR6955-R6969) [[3]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R13143-R13157) [[4]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R17884-R17898)

### Sui NTT Ownership Transfer Guidance

* Added instructions for finding the `AdminCap` and `UpgradeCap` for the NTT manager on Sui, facilitating ownership transfer procedures. [[1]](diffhunk://#diff-eda56c425cc1cef8282d82d72de035b38f4d1750de10183800e7f9010caff0ddR44) [[2]](diffhunk://#diff-66eda1dd6c6867ccbded68d5b724801ed92f5a20e50b121b6a0991f00db8afebR6933) [[3]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R13121) [[4]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R17862)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
