### PR TITLE
Martinh/connect faqs

### DIFF
--- a/.snippets/code/products/connect/faqs/faqs-1.ts
+++ b/.snippets/code/products/connect/faqs/faqs-1.ts
@@ -1,0 +1,13 @@
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route }) => {
+    if (route === 'AutomaticTokenBridge') {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};

--- a/.snippets/code/products/connect/faqs/faqs-2.ts
+++ b/.snippets/code/products/connect/faqs/faqs-2.ts
@@ -1,0 +1,21 @@
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};

--- a/.snippets/code/products/connect/faqs/faqs-3.ts
+++ b/.snippets/code/products/connect/faqs/faqs-3.ts
@@ -1,0 +1,18 @@
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};

--- a/.snippets/code/products/connect/faqs/faqs-4.ts
+++ b/.snippets/code/products/connect/faqs/faqs-4.ts
@@ -1,0 +1,18 @@
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -3543,17 +3543,17 @@ Common patterns you can implement include:
 
 ```typescript
 import WormholeConnect, {
-    type config,
+  type config,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: config.WormholeConnectConfig = {
-    // ...
-    isRouteSupportedHandler: async ({ route }) => {
-        if (route === 'AutomaticTokenBridge') {
-            return false;
-        }
-        return true; // keep other routes visible
-    },
+  // ...
+  isRouteSupportedHandler: async ({ route }) =&gt; {
+    if (route === 'AutomaticTokenBridge') {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
 };
 ```
 
@@ -3568,12 +3568,12 @@ const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromToken }) => {
+  isRouteSupportedHandler: async ({ route, fromToken }) =&gt; {
     const tokenAddress =
       fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
 
     if (
-      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      BLOCKED_ADDRESSES.has(tokenAddress) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -3581,6 +3581,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</string>
 ```
 
 **Example: Disable AutomaticTokenBridge from a specific chain**
@@ -3590,13 +3591,13 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+const BLOCKED_SOURCE_CHAINS = new Set<chain>(['INSERT_CHAIN_NAME']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromChain }) => {
+  isRouteSupportedHandler: async ({ route, fromChain }) =&gt; {
     if (
-      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -3604,6 +3605,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</chain>
 ```
 
 ## How can I hide specific tokens from the picker?
@@ -3617,22 +3619,21 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_ADDRESSES = new Set<string>([
-  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
-]);
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isTokenSupportedHandler: (token) => {
+  isTokenSupportedHandler: (token) =&gt; {
     // Address string provided by Connect
     const addr = token.addressString;
 
-    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+    if (addr &amp;&amp; BLOCKED_ADDRESSES.has(addr)) {
       return false;
     }
     return true; // show all others
   },
 };
+</string>
 ```
 
 ## Which functions or events does Connect rely on for NTT integration? 

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -3539,7 +3539,7 @@ Common patterns you can implement include:
  - Disabling routes by token using `fromToken` or `toToken`.
  - Disabling routes by direction using `fromChain` or `toChain`.
 
-**Example: Disable all AutomaticTokenBridge routes**
+**Example: Disable all `AutomaticTokenBridge` routes**
 
 ```typescript
 import WormholeConnect, {
@@ -3584,7 +3584,7 @@ const config: config.WormholeConnectConfig = {
 </string>
 ```
 
-**Example: Disable AutomaticTokenBridge from a specific chain**
+**Example: Disable `AutomaticTokenBridge` from a specific chain**
 
 ```typescript
 import WormholeConnect, {
@@ -3612,7 +3612,7 @@ const config: config.WormholeConnectConfig = {
 
 Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
 
-**Example: hide a token by address**
+**Example: Hide a token by address**
 
 ```typescript
 import WormholeConnect, {

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -3529,6 +3529,112 @@ Gas dropoff allows users to receive gas for transaction fees on the destination 
 
 Connect can be [fully customized](https://connect-in-style.wormhole.com/){target=\_blank} to choose the chains and assets you wish to support. You may also select different themes and colors to tailor Connect for your decentralized application. For details, see the [GitHub readme](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank}.
 
+## How can I disable specific routes?
+
+Use `isRouteSupportedHandler` in your `WormholeConnectConfig`. The callback runs when Connect evaluates a route for the current selection. If it returns `false`, that exact route is hidden in the widget, so the user cannot select it.
+
+Common patterns you can implement include:
+
+ - Disabling all routes of a given type (`AutomaticTokenBridge` or `ManualTokenBridge`).
+ - Disabling routes by token using `fromToken` or `toToken`.
+ - Disabling routes by direction using `fromChain` or `toChain`.
+
+**Example: Disable all AutomaticTokenBridge routes**
+
+```typescript
+import WormholeConnect, {
+    type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+    // ...
+    isRouteSupportedHandler: async ({ route }) => {
+        if (route === 'AutomaticTokenBridge') {
+            return false;
+        }
+        return true; // keep other routes visible
+    },
+};
+```
+
+**Example: Disable a specific route for a particular token**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+**Example: Disable AutomaticTokenBridge from a specific chain**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+## How can I hide specific tokens from the picker?
+
+Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
+
+**Example: hide a token by address**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>([
+  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
+]);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -1011,6 +1011,112 @@ Gas dropoff allows users to receive gas for transaction fees on the destination 
 
 Connect can be [fully customized](https://connect-in-style.wormhole.com/){target=\_blank} to choose the chains and assets you wish to support. You may also select different themes and colors to tailor Connect for your decentralized application. For details, see the [GitHub readme](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank}.
 
+## How can I disable specific routes?
+
+Use `isRouteSupportedHandler` in your `WormholeConnectConfig`. The callback runs when Connect evaluates a route for the current selection. If it returns `false`, that exact route is hidden in the widget, so the user cannot select it.
+
+Common patterns you can implement include:
+
+ - Disabling all routes of a given type (`AutomaticTokenBridge` or `ManualTokenBridge`).
+ - Disabling routes by token using `fromToken` or `toToken`.
+ - Disabling routes by direction using `fromChain` or `toChain`.
+
+**Example: Disable all AutomaticTokenBridge routes**
+
+```typescript
+import WormholeConnect, {
+    type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+    // ...
+    isRouteSupportedHandler: async ({ route }) => {
+        if (route === 'AutomaticTokenBridge') {
+            return false;
+        }
+        return true; // keep other routes visible
+    },
+};
+```
+
+**Example: Disable a specific route for a particular token**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+**Example: Disable AutomaticTokenBridge from a specific chain**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+## How can I hide specific tokens from the picker?
+
+Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
+
+**Example: hide a token by address**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>([
+  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
+]);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -1021,7 +1021,7 @@ Common patterns you can implement include:
  - Disabling routes by token using `fromToken` or `toToken`.
  - Disabling routes by direction using `fromChain` or `toChain`.
 
-**Example: Disable all AutomaticTokenBridge routes**
+**Example: Disable all `AutomaticTokenBridge` routes**
 
 ```typescript
 import WormholeConnect, {
@@ -1066,7 +1066,7 @@ const config: config.WormholeConnectConfig = {
 </string>
 ```
 
-**Example: Disable AutomaticTokenBridge from a specific chain**
+**Example: Disable `AutomaticTokenBridge` from a specific chain**
 
 ```typescript
 import WormholeConnect, {
@@ -1094,7 +1094,7 @@ const config: config.WormholeConnectConfig = {
 
 Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
 
-**Example: hide a token by address**
+**Example: Hide a token by address**
 
 ```typescript
 import WormholeConnect, {

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -1025,17 +1025,17 @@ Common patterns you can implement include:
 
 ```typescript
 import WormholeConnect, {
-    type config,
+  type config,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: config.WormholeConnectConfig = {
-    // ...
-    isRouteSupportedHandler: async ({ route }) => {
-        if (route === 'AutomaticTokenBridge') {
-            return false;
-        }
-        return true; // keep other routes visible
-    },
+  // ...
+  isRouteSupportedHandler: async ({ route }) =&gt; {
+    if (route === 'AutomaticTokenBridge') {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
 };
 ```
 
@@ -1050,12 +1050,12 @@ const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromToken }) => {
+  isRouteSupportedHandler: async ({ route, fromToken }) =&gt; {
     const tokenAddress =
       fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
 
     if (
-      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      BLOCKED_ADDRESSES.has(tokenAddress) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -1063,6 +1063,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</string>
 ```
 
 **Example: Disable AutomaticTokenBridge from a specific chain**
@@ -1072,13 +1073,13 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+const BLOCKED_SOURCE_CHAINS = new Set<chain>(['INSERT_CHAIN_NAME']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromChain }) => {
+  isRouteSupportedHandler: async ({ route, fromChain }) =&gt; {
     if (
-      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -1086,6 +1087,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</chain>
 ```
 
 ## How can I hide specific tokens from the picker?
@@ -1099,22 +1101,21 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_ADDRESSES = new Set<string>([
-  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
-]);
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isTokenSupportedHandler: (token) => {
+  isTokenSupportedHandler: (token) =&gt; {
     // Address string provided by Connect
     const addr = token.addressString;
 
-    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+    if (addr &amp;&amp; BLOCKED_ADDRESSES.has(addr)) {
       return false;
     }
     return true; // show all others
   },
 };
+</string>
 ```
 
 ## Which functions or events does Connect rely on for NTT integration? 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -11364,6 +11364,112 @@ Gas dropoff allows users to receive gas for transaction fees on the destination 
 
 Connect can be [fully customized](https://connect-in-style.wormhole.com/){target=\_blank} to choose the chains and assets you wish to support. You may also select different themes and colors to tailor Connect for your decentralized application. For details, see the [GitHub readme](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank}.
 
+## How can I disable specific routes?
+
+Use `isRouteSupportedHandler` in your `WormholeConnectConfig`. The callback runs when Connect evaluates a route for the current selection. If it returns `false`, that exact route is hidden in the widget, so the user cannot select it.
+
+Common patterns you can implement include:
+
+ - Disabling all routes of a given type (`AutomaticTokenBridge` or `ManualTokenBridge`).
+ - Disabling routes by token using `fromToken` or `toToken`.
+ - Disabling routes by direction using `fromChain` or `toChain`.
+
+**Example: Disable all AutomaticTokenBridge routes**
+
+```typescript
+import WormholeConnect, {
+    type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+    // ...
+    isRouteSupportedHandler: async ({ route }) => {
+        if (route === 'AutomaticTokenBridge') {
+            return false;
+        }
+        return true; // keep other routes visible
+    },
+};
+```
+
+**Example: Disable a specific route for a particular token**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+**Example: Disable AutomaticTokenBridge from a specific chain**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+## How can I hide specific tokens from the picker?
+
+Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
+
+**Example: hide a token by address**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>([
+  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
+]);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -11374,7 +11374,7 @@ Common patterns you can implement include:
  - Disabling routes by token using `fromToken` or `toToken`.
  - Disabling routes by direction using `fromChain` or `toChain`.
 
-**Example: Disable all AutomaticTokenBridge routes**
+**Example: Disable all `AutomaticTokenBridge` routes**
 
 ```typescript
 import WormholeConnect, {
@@ -11419,7 +11419,7 @@ const config: config.WormholeConnectConfig = {
 </string>
 ```
 
-**Example: Disable AutomaticTokenBridge from a specific chain**
+**Example: Disable `AutomaticTokenBridge` from a specific chain**
 
 ```typescript
 import WormholeConnect, {
@@ -11447,7 +11447,7 @@ const config: config.WormholeConnectConfig = {
 
 Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
 
-**Example: hide a token by address**
+**Example: Hide a token by address**
 
 ```typescript
 import WormholeConnect, {

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -11378,17 +11378,17 @@ Common patterns you can implement include:
 
 ```typescript
 import WormholeConnect, {
-    type config,
+  type config,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: config.WormholeConnectConfig = {
-    // ...
-    isRouteSupportedHandler: async ({ route }) => {
-        if (route === 'AutomaticTokenBridge') {
-            return false;
-        }
-        return true; // keep other routes visible
-    },
+  // ...
+  isRouteSupportedHandler: async ({ route }) =&gt; {
+    if (route === 'AutomaticTokenBridge') {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
 };
 ```
 
@@ -11403,12 +11403,12 @@ const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromToken }) => {
+  isRouteSupportedHandler: async ({ route, fromToken }) =&gt; {
     const tokenAddress =
       fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
 
     if (
-      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      BLOCKED_ADDRESSES.has(tokenAddress) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -11416,6 +11416,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</string>
 ```
 
 **Example: Disable AutomaticTokenBridge from a specific chain**
@@ -11425,13 +11426,13 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+const BLOCKED_SOURCE_CHAINS = new Set<chain>(['INSERT_CHAIN_NAME']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromChain }) => {
+  isRouteSupportedHandler: async ({ route, fromChain }) =&gt; {
     if (
-      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -11439,6 +11440,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</chain>
 ```
 
 ## How can I hide specific tokens from the picker?
@@ -11452,22 +11454,21 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_ADDRESSES = new Set<string>([
-  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
-]);
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isTokenSupportedHandler: (token) => {
+  isTokenSupportedHandler: (token) =&gt; {
     // Address string provided by Connect
     const addr = token.addressString;
 
-    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+    if (addr &amp;&amp; BLOCKED_ADDRESSES.has(addr)) {
       return false;
     }
     return true; // show all others
   },
 };
+</string>
 ```
 
 ## Which functions or events does Connect rely on for NTT integration? 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5045,7 +5045,7 @@ Common patterns you can implement include:
  - Disabling routes by token using `fromToken` or `toToken`.
  - Disabling routes by direction using `fromChain` or `toChain`.
 
-**Example: Disable all AutomaticTokenBridge routes**
+**Example: Disable all `AutomaticTokenBridge` routes**
 
 ```typescript
 import WormholeConnect, {
@@ -5090,7 +5090,7 @@ const config: config.WormholeConnectConfig = {
 </string>
 ```
 
-**Example: Disable AutomaticTokenBridge from a specific chain**
+**Example: Disable `AutomaticTokenBridge` from a specific chain**
 
 ```typescript
 import WormholeConnect, {
@@ -5118,7 +5118,7 @@ const config: config.WormholeConnectConfig = {
 
 Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
 
-**Example: hide a token by address**
+**Example: Hide a token by address**
 
 ```typescript
 import WormholeConnect, {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5035,6 +5035,112 @@ Gas dropoff allows users to receive gas for transaction fees on the destination 
 
 Connect can be [fully customized](https://connect-in-style.wormhole.com/){target=\_blank} to choose the chains and assets you wish to support. You may also select different themes and colors to tailor Connect for your decentralized application. For details, see the [GitHub readme](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank}.
 
+## How can I disable specific routes?
+
+Use `isRouteSupportedHandler` in your `WormholeConnectConfig`. The callback runs when Connect evaluates a route for the current selection. If it returns `false`, that exact route is hidden in the widget, so the user cannot select it.
+
+Common patterns you can implement include:
+
+ - Disabling all routes of a given type (`AutomaticTokenBridge` or `ManualTokenBridge`).
+ - Disabling routes by token using `fromToken` or `toToken`.
+ - Disabling routes by direction using `fromChain` or `toChain`.
+
+**Example: Disable all AutomaticTokenBridge routes**
+
+```typescript
+import WormholeConnect, {
+    type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+    // ...
+    isRouteSupportedHandler: async ({ route }) => {
+        if (route === 'AutomaticTokenBridge') {
+            return false;
+        }
+        return true; // keep other routes visible
+    },
+};
+```
+
+**Example: Disable a specific route for a particular token**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+**Example: Disable AutomaticTokenBridge from a specific chain**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+## How can I hide specific tokens from the picker?
+
+Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
+
+**Example: hide a token by address**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>([
+  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
+]);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5049,17 +5049,17 @@ Common patterns you can implement include:
 
 ```typescript
 import WormholeConnect, {
-    type config,
+  type config,
 } from '@wormhole-foundation/wormhole-connect';
 
 const config: config.WormholeConnectConfig = {
-    // ...
-    isRouteSupportedHandler: async ({ route }) => {
-        if (route === 'AutomaticTokenBridge') {
-            return false;
-        }
-        return true; // keep other routes visible
-    },
+  // ...
+  isRouteSupportedHandler: async ({ route }) =&gt; {
+    if (route === 'AutomaticTokenBridge') {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
 };
 ```
 
@@ -5074,12 +5074,12 @@ const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromToken }) => {
+  isRouteSupportedHandler: async ({ route, fromToken }) =&gt; {
     const tokenAddress =
       fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
 
     if (
-      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      BLOCKED_ADDRESSES.has(tokenAddress) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -5087,6 +5087,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</string>
 ```
 
 **Example: Disable AutomaticTokenBridge from a specific chain**
@@ -5096,13 +5097,13 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+const BLOCKED_SOURCE_CHAINS = new Set<chain>(['INSERT_CHAIN_NAME']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isRouteSupportedHandler: async ({ route, fromChain }) => {
+  isRouteSupportedHandler: async ({ route, fromChain }) =&gt; {
     if (
-      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &amp;&amp;
       route === 'AutomaticTokenBridge'
     ) {
       return false;
@@ -5110,6 +5111,7 @@ const config: config.WormholeConnectConfig = {
     return true; // keep other routes visible
   },
 };
+</chain>
 ```
 
 ## How can I hide specific tokens from the picker?
@@ -5123,22 +5125,21 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_ADDRESSES = new Set<string>([
-  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
-]);
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...
-  isTokenSupportedHandler: (token) => {
+  isTokenSupportedHandler: (token) =&gt; {
     // Address string provided by Connect
     const addr = token.addressString;
 
-    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+    if (addr &amp;&amp; BLOCKED_ADDRESSES.has(addr)) {
       return false;
     }
     return true; // show all others
   },
 };
+</string>
 ```
 
 ## Which functions or events does Connect rely on for NTT integration? 

--- a/products/connect/faqs.md
+++ b/products/connect/faqs.md
@@ -34,6 +34,83 @@ Gas dropoff allows users to receive gas for transaction fees on the destination 
 
 Connect can be [fully customized](https://connect-in-style.wormhole.com/){target=\_blank} to choose the chains and assets you wish to support. You may also select different themes and colors to tailor Connect for your decentralized application. For details, see the [GitHub readme](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank}.
 
+## How can I disable specific routes?
+
+Use `isRouteSupportedHandler` in your `WormholeConnectConfig`. The callback runs when Connect evaluates a route for the current selection. If it returns `false`, that exact route is hidden in the widget, so the user cannot select it.
+
+Common patterns you can implement include:
+
+ - Disabling all routes of a given type (`AutomaticTokenBridge` or `ManualTokenBridge`).
+ - Disabling routes by token using `fromToken` or `toToken`.
+ - Disabling routes by direction using `fromChain` or `toChain`.
+
+**Example: Disable all AutomaticTokenBridge routes**
+
+```typescript
+import WormholeConnect, {
+    type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const config: config.WormholeConnectConfig = {
+    // ...
+    isRouteSupportedHandler: async ({ route }) => {
+        if (route === 'AutomaticTokenBridge') {
+            return false;
+        }
+        return true; // keep other routes visible
+    },
+};
+```
+
+**Example: Disable a specific route for a particular token**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromToken }) => {
+    const tokenAddress =
+      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
+
+    if (
+      BLOCKED_ADDRESSES.has(tokenAddress) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
+**Example: Disable AutomaticTokenBridge from a specific chain**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isRouteSupportedHandler: async ({ route, fromChain }) => {
+    if (
+      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
+      route === 'AutomaticTokenBridge'
+    ) {
+      return false;
+    }
+    return true; // keep other routes visible
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/products/connect/faqs.md
+++ b/products/connect/faqs.md
@@ -44,7 +44,7 @@ Common patterns you can implement include:
  - Disabling routes by token using `fromToken` or `toToken`.
  - Disabling routes by direction using `fromChain` or `toChain`.
 
-**Example: Disable all AutomaticTokenBridge routes**
+**Example: Disable all `AutomaticTokenBridge` routes**
 
 ```typescript
 --8<-- 'code/products/connect/faqs/faqs-1.ts'
@@ -56,7 +56,7 @@ Common patterns you can implement include:
 --8<-- 'code/products/connect/faqs/faqs-2.ts'
 ```
 
-**Example: Disable AutomaticTokenBridge from a specific chain**
+**Example: Disable `AutomaticTokenBridge` from a specific chain**
 
 ```typescript
 --8<-- 'code/products/connect/faqs/faqs-3.ts'
@@ -66,7 +66,7 @@ Common patterns you can implement include:
 
 Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
 
-**Example: hide a token by address**
+**Example: Hide a token by address**
 
 ```typescript
 --8<-- 'code/products/connect/faqs/faqs-4.ts'

--- a/products/connect/faqs.md
+++ b/products/connect/faqs.md
@@ -111,6 +111,35 @@ const config: config.WormholeConnectConfig = {
 };
 ```
 
+## How can I hide specific tokens from the picker?
+
+Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs for each token candidate; if it returns `false`, that token is not shown in the picker and can't be selected.
+
+**Example: hide a token by address**
+
+```typescript
+import WormholeConnect, {
+  type config,
+} from '@wormhole-foundation/wormhole-connect';
+
+const BLOCKED_ADDRESSES = new Set<string>([
+  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
+]);
+
+const config: config.WormholeConnectConfig = {
+  // ...
+  isTokenSupportedHandler: (token) => {
+    // Address string provided by Connect
+    const addr = token.addressString;
+
+    if (addr && BLOCKED_ADDRESSES.has(addr)) {
+      return false;
+    }
+    return true; // show all others
+  },
+};
+```
+
 ## Which functions or events does Connect rely on for NTT integration? 
 
 Connect relies on the NTT SDK for integration, with platform-specific implementations for Solana and EVM. The critical methods involved include initiate and redeem functions and rate capacity methods. These functions ensure Connect can handle token transfers and manage chain-rate limits.

--- a/products/connect/faqs.md
+++ b/products/connect/faqs.md
@@ -122,9 +122,7 @@ import WormholeConnect, {
   type config,
 } from '@wormhole-foundation/wormhole-connect';
 
-const BLOCKED_ADDRESSES = new Set<string>([
-  'INSERT_TOKEN_ADDRESS'.toLowerCase(),
-]);
+const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
 
 const config: config.WormholeConnectConfig = {
   // ...

--- a/products/connect/faqs.md
+++ b/products/connect/faqs.md
@@ -47,68 +47,19 @@ Common patterns you can implement include:
 **Example: Disable all AutomaticTokenBridge routes**
 
 ```typescript
-import WormholeConnect, {
-    type config,
-} from '@wormhole-foundation/wormhole-connect';
-
-const config: config.WormholeConnectConfig = {
-    // ...
-    isRouteSupportedHandler: async ({ route }) => {
-        if (route === 'AutomaticTokenBridge') {
-            return false;
-        }
-        return true; // keep other routes visible
-    },
-};
+--8<-- 'code/products/connect/faqs/faqs-1.ts'
 ```
 
 **Example: Disable a specific route for a particular token**
 
 ```typescript
-import WormholeConnect, {
-  type config,
-} from '@wormhole-foundation/wormhole-connect';
-
-const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
-
-const config: config.WormholeConnectConfig = {
-  // ...
-  isRouteSupportedHandler: async ({ route, fromToken }) => {
-    const tokenAddress =
-      fromToken.tokenId !== 'native' ? fromToken.tokenId.address : 'native';
-
-    if (
-      BLOCKED_ADDRESSES.has(tokenAddress) &&
-      route === 'AutomaticTokenBridge'
-    ) {
-      return false;
-    }
-    return true; // keep other routes visible
-  },
-};
+--8<-- 'code/products/connect/faqs/faqs-2.ts'
 ```
 
 **Example: Disable AutomaticTokenBridge from a specific chain**
 
 ```typescript
-import WormholeConnect, {
-  type config,
-} from '@wormhole-foundation/wormhole-connect';
-
-const BLOCKED_SOURCE_CHAINS = new Set<Chain>(['INSERT_CHAIN_NAME']);
-
-const config: config.WormholeConnectConfig = {
-  // ...
-  isRouteSupportedHandler: async ({ route, fromChain }) => {
-    if (
-      BLOCKED_SOURCE_CHAINS.has(fromChain) &&
-      route === 'AutomaticTokenBridge'
-    ) {
-      return false;
-    }
-    return true; // keep other routes visible
-  },
-};
+--8<-- 'code/products/connect/faqs/faqs-3.ts'
 ```
 
 ## How can I hide specific tokens from the picker?
@@ -118,24 +69,7 @@ Use `isTokenSupportedHandler` in your `WormholeConnectConfig`. The callback runs
 **Example: hide a token by address**
 
 ```typescript
-import WormholeConnect, {
-  type config,
-} from '@wormhole-foundation/wormhole-connect';
-
-const BLOCKED_ADDRESSES = new Set<string>(['INSERT_TOKEN_ADDRESS']);
-
-const config: config.WormholeConnectConfig = {
-  // ...
-  isTokenSupportedHandler: (token) => {
-    // Address string provided by Connect
-    const addr = token.addressString;
-
-    if (addr && BLOCKED_ADDRESSES.has(addr)) {
-      return false;
-    }
-    return true; // show all others
-  },
-};
+--8<-- 'code/products/connect/faqs/faqs-4.ts'
 ```
 
 ## Which functions or events does Connect rely on for NTT integration? 


### PR DESCRIPTION
### Description

This pull request updates the documentation for Wormhole Connect across multiple files to provide clear guidance on how developers can customize which routes and tokens are available in the Connect widget. The new sections explain how to use the `isRouteSupportedHandler` and `isTokenSupportedHandler` configuration callbacks, with practical TypeScript code examples for common scenarios.

Configuration customization documentation:

* Added instructions for using `isRouteSupportedHandler` in `WormholeConnectConfig` to control which transfer routes are visible to users, including examples for disabling routes by type, token, or chain. [[1]](diffhunk://#diff-bf0b4bbd3a60a6f23d50f1c268614409f37d1cd423efda8dd5ba0544eab5c56fR37-R142) [[2]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R5038-R5143) [[3]](diffhunk://#diff-bdc4a3fd4bc3b7983bdacfadf03530074922a9849f935b01a1d542587a082528R3532-R3637) [[4]](diffhunk://#diff-6c27d13b13970bc40f4abe2ac59f12147345db67dc1c40657f0ad253a45f62d6R1014-R1119) [[5]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R11367-R11472)
* Added instructions for using `isTokenSupportedHandler` in `WormholeConnectConfig` to hide specific tokens from the picker, with code examples for blocking tokens by address. [[1]](diffhunk://#diff-bf0b4bbd3a60a6f23d50f1c268614409f37d1cd423efda8dd5ba0544eab5c56fR37-R142) [[2]](diffhunk://#diff-db21784bc3b6a3059d3447a91541acd3f88e0b0f943baee38483f38ba9a7c714R5038-R5143) [[3]](diffhunk://#diff-bdc4a3fd4bc3b7983bdacfadf03530074922a9849f935b01a1d542587a082528R3532-R3637) [[4]](diffhunk://#diff-6c27d13b13970bc40f4abe2ac59f12147345db67dc1c40657f0ad253a45f62d6R1014-R1119) [[5]](diffhunk://#diff-b3b0126395bd34c4f3825183eaf67336e92d4c93dca180d6d44fbae7f379fa54R11367-R11472)

These changes make it easier for developers to tailor the Connect widget to their application's needs by programmatically controlling available routes and tokens.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
