### PR TITLE
adjust replay protection comment in the docs

### DIFF
--- a/.snippets/code/products/messaging/guides/wormhole-relayers/receiveWormholeMessages.sol
+++ b/.snippets/code/products/messaging/guides/wormhole-relayers/receiveWormholeMessages.sol
@@ -3,5 +3,5 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;

--- a/llms-files/llms-basics.txt
+++ b/llms-files/llms-basics.txt
@@ -1695,7 +1695,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -1735,7 +1735,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -5368,7 +5368,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -5408,7 +5408,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -3835,7 +3835,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -3875,7 +3875,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -2773,7 +2773,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -2813,7 +2813,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -10192,7 +10192,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -10232,7 +10232,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -2495,7 +2495,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -2535,7 +2535,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -152,7 +152,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -192,7 +192,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.
@@ -2242,7 +2241,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -2282,7 +2281,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -2206,7 +2206,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -2246,7 +2246,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -18353,7 +18353,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -18393,7 +18393,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -6387,7 +6387,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -6427,7 +6427,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -5256,7 +5256,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -5296,7 +5296,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7930,7 +7930,7 @@ function receiveWormholeMessages(
     bytes[] memory additionalVaas,  // Any additional VAAs that are needed (Note: these are unverified) 
     bytes32 sourceAddress,          // The address of the source contract
     uint16 sourceChain,             // The Wormhole chain ID
-    bytes32 deliveryHash            // A hash of contents, useful for replay protection
+    bytes32 deliveryHash            // A hash of contents, useful for core Wormhole replay protection
 ) external payable;
 ```
 
@@ -7970,7 +7970,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.

--- a/products/messaging/guides/wormhole-relayers.md
+++ b/products/messaging/guides/wormhole-relayers.md
@@ -114,7 +114,6 @@ Some implementation details should be considered during development to ensure sa
 - Receiving a message from a relayer.
 - Checking for expected emitter.
 - Calling `parseAndVerify` on any additional VAAs.
-- Replay protection.
 - Message ordering (no guarantees on order of messages delivered).
 - Forwarding and call chaining.
 - Refunding overpayment of `gasLimit`.


### PR DESCRIPTION
### Description

This pull request makes minor documentation and comment updates across multiple Wormhole Relayer guide and implementation files. Clarifying the purpose of the `deliveryHash` parameter in the `receiveWormholeMessages` function, specifying its use for core Wormhole replay protection.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
