### PR TITLE
Ilariae/add multigov XRPL-EVM address

### DIFF
--- a/.snippets/text/products/reference/contract-addresses/governance.md
+++ b/.snippets/text/products/reference/contract-addresses/governance.md
@@ -9,5 +9,6 @@
     <tr><td>HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' }</td><td><code>0x574B7864119C9223A9870Ea614dC91A8EE09E512</code></td></tr>
     <tr><td>Optimism</td><td><code>0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8</code></td></tr>
     <tr><td>Unichain</td><td><code>0x574b7864119c9223a9870ea614dc91a8ee09e512</code></td></tr>
+    <tr><td>XRPL-EVM</td><td><code>0x574B7864119C9223A9870Ea614dC91A8EE09E512</code></td></tr>
     </tbody>
     </table>

--- a/llms-files/llms-cctp.txt
+++ b/llms-files/llms-cctp.txt
@@ -12773,6 +12773,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-connect.txt
+++ b/llms-files/llms-connect.txt
@@ -11240,6 +11240,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-multigov.txt
+++ b/llms-files/llms-multigov.txt
@@ -10178,6 +10178,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -17597,6 +17597,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-queries.txt
+++ b/llms-files/llms-queries.txt
@@ -9900,6 +9900,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-reference.txt
+++ b/llms-files/llms-reference.txt
@@ -2735,6 +2735,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-relayers.txt
+++ b/llms-files/llms-relayers.txt
@@ -9646,6 +9646,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-settlement.txt
+++ b/llms-files/llms-settlement.txt
@@ -9611,6 +9611,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -25758,6 +25758,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-typescript-sdk.txt
+++ b/llms-files/llms-typescript-sdk.txt
@@ -13792,6 +13792,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-files/llms-wtt.txt
+++ b/llms-files/llms-wtt.txt
@@ -12661,6 +12661,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16955,6 +16955,7 @@ categories: Reference
 | HyperEVM :material-alert:{ title='⚠️ The HyperEVM integration is experimental, as its node software is not open source. Use Wormhole messaging on HyperEVM with caution.' } | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 | Optimism | 0x0E09a3081837ff23D2e59B179E0Bc48A349Afbd8 |
 | Unichain | 0x574b7864119c9223a9870ea614dc91a8ee09e512 |
+| XRPL-EVM | 0x574B7864119C9223A9870Ea614dC91A8EE09E512 |
 
 !!! note
     Guardian-governed ownership contracts are used where an owner is required, without adding new trust assumptions. They only accept instructions signed by a quorum of Wormhole Guardians, validated on-chain by the Wormhole Core contracts. Implementations: [EVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/wormhole/Governance.sol){target=\_blank} and [SVM](https://github.com/wormhole-foundation/native-token-transfers/blob/main/solana/programs/wormhole-governance/src/instructions/governance.rs){target=\_blank}.


### PR DESCRIPTION
This pull request adds support for the XRPL-EVM chain to the governance contract address reference tables across multiple documentation files. The XRPL-EVM entry is now included alongside other supported chains, ensuring that users and developers have access to the correct contract address for XRPL-EVM in all relevant reference materials.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
