### PR TITLE
Ntt evm minter clarification

### DIFF
--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -7207,7 +7207,9 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for all required functions, errors, and events.
+        You’ll also need to set mint authority to the relevant `NttManager` contract.
+
+        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 
         ??? interface "`INttToken` Interface"
             ```solidity
@@ -7248,8 +7250,6 @@ interface INttToken {
     function burn(uint256 amount) external;
 }
             ```
-
-        You’ll also need to set mint authority to the relevant `NttManager` contract.
 
     ??? interface "Hub-and-Spoke"
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -7207,7 +7207,7 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        You’ll also need to set mint authority to the relevant `NttManager` contract.
+        You'll also need to set the mint authority to the relevant `NttManager` contract.
 
         These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 

--- a/llms-files/llms-ntt.txt
+++ b/llms-files/llms-ntt.txt
@@ -7207,7 +7207,7 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        You'll also need to set the mint authority to the relevant `NttManager` contract.
+        You’ll also need to set mint authority to the relevant `NttManager` contract.
 
         These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 

--- a/llms-files/llms-transfer.txt
+++ b/llms-files/llms-transfer.txt
@@ -13501,7 +13501,9 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for all required functions, errors, and events.
+        You’ll also need to set mint authority to the relevant `NttManager` contract.
+
+        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 
         ??? interface "`INttToken` Interface"
             ```solidity
@@ -13542,8 +13544,6 @@ interface INttToken {
     function burn(uint256 amount) external;
 }
             ```
-
-        You’ll also need to set mint authority to the relevant `NttManager` contract.
 
     ??? interface "Hub-and-Spoke"
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -19180,7 +19180,9 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for all required functions, errors, and events.
+        You’ll also need to set mint authority to the relevant `NttManager` contract.
+
+        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 
         ??? interface "`INttToken` Interface"
             ```solidity
@@ -19221,8 +19223,6 @@ interface INttToken {
     function burn(uint256 amount) external;
 }
             ```
-
-        You’ll also need to set mint authority to the relevant `NttManager` contract.
 
     ??? interface "Hub-and-Spoke"
 

--- a/products/token-transfers/native-token-transfers/guides/deploy-to-evm.md
+++ b/products/token-transfers/native-token-transfers/guides/deploy-to-evm.md
@@ -37,14 +37,14 @@ Deploying NTT on EVM chains follows a structured process:
         - `burn(uint256 amount)`
         - `mint(address account, uint256 amount)`
 
-        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for all required functions, errors, and events.
+        You’ll also need to set mint authority to the relevant `NttManager` contract.
+
+        These functions aren't part of the standard ERC-20 interface. Refer to the [`INttToken` interface](https://github.com/wormhole-foundation/native-token-transfers/blob/main/evm/src/interfaces/INttToken.sol){target=\_blank} for examples of the mentioned functions, as well as optional errors and events.
 
         ??? interface "`INttToken` Interface"
             ```solidity
             --8<-- 'code/products/native-token-transfers/guides/deploy-to-evm/INttToken.sol'
             ```
-
-        You’ll also need to set mint authority to the relevant `NttManager` contract.
 
     ??? interface "Hub-and-Spoke"
 


### PR DESCRIPTION
### Description

Documentation improvements:

* Added explicit instruction to set mint authority to the relevant `NttManager` contract in the deployment guides and reference files.
* Updated the description of the `INttToken` interface to reference examples and optional errors/events, making the documentation more accurate and less prescriptive.

Redundant information cleanup:

* Removed duplicate instructions about setting mint authority to the `NttManager` contract from sections following the code examples, streamlining the documentation.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly
