### PR TITLE
Patches prompting for open in chatGPT to improve UX

### DIFF
--- a/js/copy-to-llms.js
+++ b/js/copy-to-llms.js
@@ -487,7 +487,7 @@
             trackButtonClick('open_chatgpt');
             const currentUrl = window.location.href;
             const jinaUrl = `https://r.jina.ai/${currentUrl}`;
-            const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about implementing these protocols.`;;
+            const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about implementing these protocols.`;
             const chatGPTUrl = `https://chatgpt.com/?q=${encodeURIComponent
               (prompt)
             }`;

--- a/js/copy-to-llms.js
+++ b/js/copy-to-llms.js
@@ -485,11 +485,12 @@
           }
           case 'open-chatgpt': {
             trackButtonClick('open_chatgpt');
-            const mdUrl = getMarkdownUrl(slug);
-            const prompt = `Read ${mdUrl} so I can ask questions about it.`;
-            const chatGPTUrl = `https://chatgpt.com/?hints=search&q=${encodeURIComponent(
-              prompt
-            )}`;
+            const currentUrl = window.location.href;
+            const jinaUrl = `https://r.jina.ai/${currentUrl}`;
+            const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about how to implement these protocols.`;;
+            const chatGPTUrl = `https://chatgpt.com/?q=${encodeURIComponent
+              (prompt)
+            }`;
             window.open(chatGPTUrl, '_blank');
             break;
           }

--- a/js/copy-to-llms.js
+++ b/js/copy-to-llms.js
@@ -487,7 +487,7 @@
             trackButtonClick('open_chatgpt');
             const currentUrl = window.location.href;
             const jinaUrl = `https://r.jina.ai/${currentUrl}`;
-            const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about how to implement these protocols.`;;
+            const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about implementing these protocols.`;;
             const chatGPTUrl = `https://chatgpt.com/?q=${encodeURIComponent
               (prompt)
             }`;

--- a/js/copy-to-llms.js
+++ b/js/copy-to-llms.js
@@ -488,9 +488,7 @@
             const currentUrl = window.location.href;
             const jinaUrl = `https://r.jina.ai/${currentUrl}`;
             const prompt = `Analyze the documentation at ${jinaUrl}. Focus on the technical implementation details and code examples. I want to ask you questions about implementing these protocols.`;
-            const chatGPTUrl = `https://chatgpt.com/?q=${encodeURIComponent
-              (prompt)
-            }`;
+            const chatGPTUrl = `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
             window.open(chatGPTUrl, '_blank');
             break;
           }


### PR DESCRIPTION
### Description

Problem: The "Open in ChatGPT" prompt was returning results like "”It looks like I couldn’t directly fetch or read the contents of the specific file you linked..." leading users to experience this feature as being broken. The "Open in Claude" button does not have this issue. 

Context: I learned this happens due to a difference in how ChatGPT and Claude "see" the web. When ChatGPT gets a prompt to look at a page, it's browsing tool uses a headless browser which tries to render it as a webpage. We are passing URLs to resolved Markdown files so it can't render as a webpage and it trips over it. 

Solution: Jina Reader (ReaderLM-v2). https://jina.ai/models/ReaderLM-v2 to the rescue. The improved flow looks like:
- Use the deployed site url and add the jina prefix (`https://r.jina.ai/${currentUrl}` where currentUrl = window.location.href
- Updated prompt avoiding words like "read" that trigger the GPT default browser activity
- Still send the chatGPTUrl the same way with the improved prompt

Example improved answer: "I successfully fetched and analyzed the “Building Protocols and Payloads” documentation from the Wormhole TypeScript SDK that you linked. Here’s a technical breakdown of the implementation details and code examples so you can ask targeted questions about how to implement these protocols yourself. <followed by summary info>

Using the jina reader in this way is free for up to 20 requests per minute. This will be the users browser hitting those so unless they want to ask a new question every three seconds, we should be ok. 

If we don't want to use Jina reader, I think we'd be best off passing the deployed webpage URL to ChatGPT rather than the one to the resolved Markdown file. It will handle those better due to the built-in headless browser being able to see HTML tags.

### Checklist

- [x ] **Required** - I have added a label to this PR 🏷️
- [ x] **Required** - I have run my changes through Grammarly
- [ n/a] If pages have been moved, I have created redirects in the `wormhole-mkdocs` repo
