### PR TITLE
Martinh/update ntt cli install

### DIFF
--- a/.snippets/text/products/native-token-transfers/guides/install-ntt-project.md
+++ b/.snippets/text/products/native-token-transfers/guides/install-ntt-project.md
@@ -1,19 +1,7 @@
 1. Install the NTT CLI:
 
     ```bash
-    git clone --branch 'v1.6.0+cli' --single-branch --depth 1 \
-        https://github.com/wormhole-foundation/native-token-transfers.git
-    cd native-token-transfers
-    ```
-
-    ```bash
-    curl -fsSL https://bun.com/install | bash -s "bun-v1.2.23"  
-    ```
-
-    ```bash
-    npm ci
-    cd cli
-    ./install.sh
+    curl -fsSL https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/cli/install.sh | bash
     ```
 
     Verify installation:

--- a/products/token-transfers/native-token-transfers/get-started.md
+++ b/products/token-transfers/native-token-transfers/get-started.md
@@ -39,29 +39,22 @@ The NTT CLI is recommended to deploy and manage your cross-chain token configura
 
 1. Run the installation commands in your terminal:
 
---8<-- 'text/products/native-token-transfers/guides/install-ntt-project.md:3:17'
-
-??? warning "Install permission denied?"
-    If the `install.sh` could not be executed due to file permissions, you need to change the ownership of the executable file. For example:
-
-    ```bash
-    chmod u+x ./install.sh
-    ```
+--8<-- 'text/products/native-token-transfers/guides/install-ntt-project.md:3:5'
 
 2. Verify the NTT CLI is installed:
 
---8<-- 'text/products/native-token-transfers/guides/install-ntt-project.md:21:23'
+--8<-- 'text/products/native-token-transfers/guides/install-ntt-project.md:9:11'
 
-??? warning "Command not found?"
-    If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) v1.2.23 is installed and that its binary directory is included in your shell’s PATH.
-    
-    Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
+    ??? warning "Command not found?"
+        If the `ntt` command is not recognized after installation, ensure that [Bun](https://bun.sh/) v1.2.23 is installed and that its binary directory is included in your shell’s PATH.
+        
+        Append this line to your shell config (e.g., `~/.zshrc` or `~/.bashrc`):
 
-    ```bash
-    echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
-    ```
+        ```bash
+        echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+        ```
 
-    Then, restart your terminal or run `source ~/.zshrc`.
+        Then, restart your terminal or run `source ~/.zshrc`.
 
 ## Initialize a New NTT Project
 


### PR DESCRIPTION
### Description

This pull request updates the installation instructions for the NTT CLI to simplify the process and improve user guidance. The most important changes are grouped below:

Installation process simplification:

* Updated the installation method in `install-ntt-project.md` to use a single `curl | bash` command for installing the NTT CLI, replacing the previous multi-step process involving git clone, Bun installation, and manual script execution.

User guidance improvements:

* Removed the warning and instructions about file permissions for `install.sh` from the `get-started.md` documentation, as the new installation method no longer requires manual script execution.
* Retained and clarified the warning about the `ntt` command not being found, advising users to ensure Bun is installed and its binary directory is in the PATH.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] **Required** - I have run my changes through Grammarly