### PR TITLE
Update NTT config URLs to use main branch

### DIFF
--- a/scripts/src/config/contracts-config.json
+++ b/scripts/src/config/contracts-config.json
@@ -1,18 +1,18 @@
 {
 	"sources": {
 		"ntt_mainnet": {
-			"contracts_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/evm/ts-scripts/config/mainnet/contracts.json",
-			"chains_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/evm/ts-scripts/config/mainnet/chains.json"
+			"contracts_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/evm/ts-scripts/config/mainnet/contracts.json",
+			"chains_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/evm/ts-scripts/config/mainnet/chains.json"
 		},
 		"ntt_testnet": {
-			"contracts_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/evm/ts-scripts/config/testnet/contracts.json",
-			"chains_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/evm/ts-scripts/config/testnet/chains.json"
+			"contracts_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/evm/ts-scripts/config/testnet/contracts.json",
+			"chains_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/evm/ts-scripts/config/testnet/chains.json"
 		},
 		"solana_mainnet": {
-			"programs_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/solana/ts/scripts/config/mainnet/programs.json"
+			"programs_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/solana/ts/scripts/config/mainnet/programs.json"
 		},
 		"solana_testnet": {
-			"programs_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/deployment-scripts/solana/ts/scripts/config/devnet/programs.json"
+			"programs_url": "https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/solana/ts/scripts/config/devnet/programs.json"
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Update `scripts/src/config/contracts-config.json` to point to the `main` branch of the NTT repo instead of `deployment-scripts`

## Context

The deployment config files have been migrated to the main branch of the NTT repo (see wormhole-foundation/native-token-transfers#812), which has prettier CI checks to catch formatting errors like wormhole-foundation/native-token-transfers#811.

This ensures future formatting issues in the JSON config files will be caught by CI.