### PR TITLE
fix(ci): use explicit GITHUB_TOKEN for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,5 +25,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Passes `github_token: ${{ secrets.GITHUB_TOKEN }}` to `claude-code-action` so it uses the workflow's own token instead of requiring the Claude Code GitHub App to be installed
- Permissions remain locked to what's declared in the workflow (`contents: read`, `pull-requests: write`, `id-token: write`)

## Test plan
- [ ] Merge to `dev`, then comment `@claude` on an open PR to verify the action runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)