### PR TITLE
Move Guardians Config to Variables

### DIFF
--- a/docs/products/messaging/guides/solana-shims/sol-emission.md
+++ b/docs/products/messaging/guides/solana-shims/sol-emission.md
@@ -10,7 +10,7 @@ The emission shim is a lightweight Solana program that lets integrators emit Wor
 
 Migrating from the legacy path is straightforward: no account resizing is needed, and programs can call the shim directly. The Wormhole fee is still paid through the `fee_collector`, with the same parallelization limits as before. 
 
-Guardians are configured to observe the canonical shim address, reading message data, emitter, and nonce from the transaction logs and CPI events, rather than on-chain accounts. They also ignore the empty core bridge payload to prevent duplicate VAAs. On mainnet, all 19 Guardians support shim emissions, and, as with all Wormhole messages, at least 13 attestations are required for a valid VAA.
+Guardians are configured to observe the canonical shim address, reading message data, emitter, and nonce from the transaction logs and CPI events, rather than on-chain accounts. They also ignore the empty core bridge payload to prevent duplicate VAAs. On mainnet, all {{ guardian_count }} Guardians support shim emissions, and, as with all Wormhole messages, at least {{ guardian_quorum }} attestations are required for a valid VAA.
 
 !!!note
     For on-chain programs that only call the shim via CPI, consider emitting a dummy/empty message after migration to avoid edge cases with initial CPI depth (Solana limits the depth of cross-program calls).

--- a/docs/products/reference/glossary.md
+++ b/docs/products/reference/glossary.md
@@ -32,7 +32,7 @@ The finality of a transaction depends on its blockchain properties. Once a trans
 
 ## Guardian
 
-A [Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank} is one of the 19 parties running validators in the Guardian Network contributing to the VAA multisig.
+A [Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank} is one of the {{ guardian_count }} parties running validators in the Guardian Network contributing to the VAA multisig.
 
 ## Guardian Network
 

--- a/docs/products/token-transfers/wrapped-token-transfers/concepts/transfer-flow.md
+++ b/docs/products/token-transfers/wrapped-token-transfers/concepts/transfer-flow.md
@@ -30,7 +30,7 @@ Cross-chain token transfers using WTT follow these steps:
 
 3. **Message Observation and Signing**
 
-    [Guardians](/docs/protocol/infrastructure/guardians/){target=\_blank}—a decentralized network of validators—monitor the source chain for these message events. A supermajority (13 out of 19) signs the event to generate a [Verified Action Approval (VAA)](/docs/protocol/infrastructure/vaas/){target=\_blank}—a cryptographically signed attestation of the transfer.
+    [Guardians](/docs/protocol/infrastructure/guardians/){target=\_blank}—a decentralized network of validators—monitor the source chain for these message events. A supermajority ({{ guardian_quorum }} out of {{ guardian_count }}) signs the event to generate a [Verified Action Approval (VAA)](/docs/protocol/infrastructure/vaas/){target=\_blank}—a cryptographically signed attestation of the transfer.
 
     The VAA is then published to the Wormhole network.
 

--- a/docs/protocol/architecture.md
+++ b/docs/protocol/architecture.md
@@ -32,7 +32,7 @@ The preceding diagram outlines the end-to-end flow of multichain communication t
 ## Off-Chain Components
 
 - **Guardian Network**: Validators that exist in their own P2P network. Guardians observe and validate the messages emitted by the Core Contract on each supported chain to produce VAAs (signed messages).
-- **[Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank}**: One of 19 validators in the Guardian Network that contributes to the VAA multisig.
+- **[Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank}**: One of {{ guardian_count }} validators in the Guardian Network that contributes to the VAA multisig.
 - **[Spy](/docs/protocol/infrastructure/spy/){target=\_blank}**: A daemon that subscribes to messages published within the Guardian Network. A Spy can observe and forward network traffic, which helps scale up VAA distribution.
 - **[API](https://docs.wormholescan.io/){target=\_blank}**: A REST server to retrieve details for a VAA or the Guardian Network.
 - **[VAAs](/docs/protocol/infrastructure/vaas/){target=\_blank}**: Verifiable Action Approvals (VAAs) are the signed attestation of an observed message from the Wormhole Core Contract.

--- a/docs/protocol/infrastructure/guardians.md
+++ b/docs/protocol/infrastructure/guardians.md
@@ -6,7 +6,7 @@ categories: Basics
 
 # Guardians
 
-Wormhole relies on a set of 19 distributed nodes that monitor the state on several blockchains. In Wormhole, these nodes are referred to as Guardians. The current Guardian set can be seen in the [Dashboard](https://wormhole-foundation.github.io/wormhole-dashboard/#/?endpoint=Mainnet){target=\_blank}.
+Wormhole relies on a set of {{ guardian_count }} distributed nodes that monitor the state on several blockchains. In Wormhole, these nodes are referred to as Guardians. The current Guardian set can be seen in the [Dashboard](https://wormhole-foundation.github.io/wormhole-dashboard/#/?endpoint=Mainnet){target=\_blank}.
 
 Guardians fulfill their role in the messaging protocol as follows: 
 
@@ -47,8 +47,8 @@ To answer that, consider these key constraints and design decisions:
 
 - **Threshold signatures allow flexibility, but**: With threshold signatures, in theory, any number of validators could participate. However, threshold signatures are not yet widely supported across blockchains. Verifying them is expensive and complex, especially in a chain-agnostic system.
 - **t-Schnorr multisig is more practical**: Wormhole uses [t-Schnorr multisig](https://en.wikipedia.org/wiki/Schnorr_signature){target=\_blank}, which is broadly supported and relatively inexpensive to verify. However, verification costs scale linearly with the number of signers, so the size of the validator set needs to be carefully chosen.
-- **19 validators is the optimal tradeoff**: A set of 19 participants presents a practical compromise between decentralization and efficiency. With a two-thirds consensus threshold, only 13 signatures must be verified on-chain—keeping gas costs reasonable while ensuring strong security.
-- **Security through reputation, not tokens**: Wormhole relies on a network of established validator companies instead of token-based incentives. These 19 Guardians are among the most trusted operators in the industry—real entities with a track record, not anonymous participants.
+- **{{ guardian_count }} validators is the optimal tradeoff**: A set of {{ guardian_count }} participants presents a practical compromise between decentralization and efficiency. With a two-thirds consensus threshold, only {{ guardian_quorum }} signatures must be verified on-chain—keeping gas costs reasonable while ensuring strong security.
+- **Security through reputation, not tokens**: Wormhole relies on a network of established validator companies instead of token-based incentives. These {{ guardian_count }} Guardians are among the most trusted operators in the industry—real entities with a track record, not anonymous participants.
 
 This forms the foundation for a purpose-built Proof-of-Authority (PoA) consensus model, where each Guardian has an equal stake. As threshold signatures gain broader support, the set can expand. Once ZKPs become widely viable, the network can evolve into a fully trustless system.
 

--- a/docs/protocol/infrastructure/vaas.md
+++ b/docs/protocol/infrastructure/vaas.md
@@ -175,7 +175,7 @@ Anyone can submit a VAA to the target chain. Guardians typically don't perform t
 
 With the concepts now defined, it is possible to illustrate a full flow for message passing between two chains. The following stages demonstrate each step of processing that the Wormhole network performs to route a message.
 
-1. **A message is emitted by a contract running on Chain A**: Any contract can emit messages, and the Guardians are programmed to observe all chains for these events. Here, the Guardians are represented as a single entity to simplify the graphics, but the observation of the message must be performed individually by each of the 19 Guardians.
+1. **A message is emitted by a contract running on Chain A**: Any contract can emit messages, and the Guardians are programmed to observe all chains for these events. Here, the Guardians are represented as a single entity to simplify the graphics, but the observation of the message must be performed individually by each of the {{ guardian_count }} Guardians.
 2. **Signatures are aggregated**: Guardians independently observe and sign the message. Once enough Guardians have signed the message, the collection of signatures is combined with the message and metadata to produce a VAA.
 3. **VAA submitted to target chain**: The VAA acts as proof that the Guardians have collectively attested the existence of the message payload. The VAA is submitted (or relayed) to the target chain to be processed by a receiving contract and complete the final step.
 

--- a/docs/protocol/security.md
+++ b/docs/protocol/security.md
@@ -8,10 +8,10 @@ categories: Basics
 
 ## Core Security Assumptions
 
-At its core, Wormhole is secured by a network of [Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank} nodes that validate and sign messages. If a super majority (e.g., 13 out of 19) of Guardians sign the same message, it can be considered valid. A smart contract on the target chain will verify the signatures and format of the message before approving any transaction.
+At its core, Wormhole is secured by a network of [Guardian](/docs/protocol/infrastructure/guardians/){target=\_blank} nodes that validate and sign messages. If a super majority (e.g., {{ guardian_quorum }} out of {{ guardian_count }}) of Guardians sign the same message, it can be considered valid. A smart contract on the target chain will verify the signatures and format of the message before approving any transaction.
 
 - Wormhole's core security primitive is its signed messages (signed [VAAs](/docs/protocol/infrastructure/vaas/){target=\_blank}).
-- The Guardian network is currently secured by a collection of 19 of the world's top [validator companies](https://wormhole-foundation.github.io/wormhole-dashboard/#/?endpoint=Mainnet){target=\_blank}.
+- The Guardian network is currently secured by a collection of {{ guardian_count }} of the world's top [validator companies](https://wormhole-foundation.github.io/wormhole-dashboard/#/?endpoint=Mainnet){target=\_blank}.
 - Guardians produce signed state attestations (signed VAAs) when requested by a Core Contract integrator.
 - Every Guardian runs full nodes (rather than light nodes) of every blockchain in the Wormhole network, so if a blockchain suffers a consensus attack or hard fork, the blockchain will disconnect from the network rather than potentially produce invalid signed VAAs.
 - Any Signed VAA can be verified as authentic by the Core Contract of any other chain.
@@ -27,7 +27,7 @@ Core assumptions aside, many other factors impact the real-world security of dec
 
 ## Guardian Network
 
-Wormhole is an evolving platform. While the Guardian set currently comprises 19 validators, this is a limitation of current blockchain technology.
+Wormhole is an evolving platform. While the Guardian set currently comprises {{ guardian_count }} validators, this is a limitation of current blockchain technology.
 
 ### Governance
 

--- a/docs/tools/dev-env.md
+++ b/docs/tools/dev-env.md
@@ -46,7 +46,7 @@ If you'd like to set up a local validator environment, follow the setup guide fo
 
 ### Testnet
 
-When doing integration testing on Testnets, remember that a single Guardian node is watching for transactions on various test networks. Because Testnets only have a single Guardian, there's a slight chance that your VAAs won't be processed. This rate doesn't indicate performance on Mainnet, where 19 Guardians are watching for transactions. The Testnet contract addresses are available on the page for each [environment](/docs/products/reference/supported-networks/){target=\_blank}. The [Wormholescan API](https://docs.wormholescan.io){target=\_blank} offers the following Guardian equivalent Testnet endpoint:
+When doing integration testing on Testnets, remember that a single Guardian node is watching for transactions on various test networks. Because Testnets only have a single Guardian, there's a slight chance that your VAAs won't be processed. This rate doesn't indicate performance on Mainnet, where {{ guardian_count }} Guardians are watching for transactions. The Testnet contract addresses are available on the page for each [environment](/docs/products/reference/supported-networks/){target=\_blank}. The [Wormholescan API](https://docs.wormholescan.io){target=\_blank} offers the following Guardian equivalent Testnet endpoint:
 
 ```text
 https://api.testnet.wormholescan.io

--- a/docs/variables.yml
+++ b/docs/variables.yml
@@ -1,3 +1,5 @@
+guardian_count: 19
+guardian_quorum: 13
 ntt:
   anchor_version: v0.29.0
   solana_cli_version: v1.18.26


### PR DESCRIPTION
### Description

This pull request updates the documentation to use template variables for the Guardian count and quorum, replacing hardcoded values throughout the docs. This makes the documentation more maintainable and easier to update if the Guardian set changes in the future. The changes touch multiple files to consistently reference `{{ guardian_count }}` and `{{ guardian_quorum }}` instead of fixed numbers.

Guardian count and quorum variableization:

* Added `guardian_count` and `guardian_quorum` variables to `docs/variables.yml` for use in documentation templates.
* Replaced all instances of hardcoded Guardian counts ("19") and quorum ("13") with `{{ guardian_count }}` and `{{ guardian_quorum }}` in files such as `docs/protocol/infrastructure/guardians.md`, `docs/protocol/security.md`, `docs/protocol/architecture.md`, `docs/products/reference/glossary.md`, `docs/products/token-transfers/wrapped-token-transfers/concepts/transfer-flow.md`, `docs/protocol/infrastructure/vaas.md`, `docs/products/messaging/guides/solana-shims/sol-emission.md`, and `docs/tools/dev-env.md`. [[1]](diffhunk://#diff-5704046957bd9ba24cdd4d1146d69c0e17443bd1d4d92c4a2ff9d3056264b62dL9-R9) [[2]](diffhunk://#diff-5704046957bd9ba24cdd4d1146d69c0e17443bd1d4d92c4a2ff9d3056264b62dL50-R51) [[3]](diffhunk://#diff-003963e35578da5a8e1ef8b52caa02424a0565df7566ae3327e9e99a613fec01L11-R14) [[4]](diffhunk://#diff-003963e35578da5a8e1ef8b52caa02424a0565df7566ae3327e9e99a613fec01L30-R30) [[5]](diffhunk://#diff-7d0dc6982308ef7730dab14bd89da64cd6d4f45b8c65f20eef7b86a93170b506L35-R35) [[6]](diffhunk://#diff-fcb2984284065083e274f2ef06822efb36710e6d5d12a6dfb45dfe25ef7e6b55L35-R35) [[7]](diffhunk://#diff-76acc8b449149da93e8d49a31c46882a98a43e04f9f28748ecc352d562f7f5a6L33-R33) [[8]](diffhunk://#diff-cdf3871194e311e0386a81a41cb29ba0593ee76ed9d6e469107d06dc92d37838L178-R178) [[9]](diffhunk://#diff-00df895537c15d5cf0cd965540e29282391873fd6e21f4883dda51300b54642eL13-R13) [[10]](diffhunk://#diff-596b51d05b25bc0f7b63fef1050031fa66b9b1dd4d3088d2ad62fc28f64e7e53L49-R49)

Documentation consistency and maintainability:

* Ensured that all references to Guardian counts and quorum across the documentation are consistent and now automatically update if the variables change. [[1]](diffhunk://#diff-5704046957bd9ba24cdd4d1146d69c0e17443bd1d4d92c4a2ff9d3056264b62dL9-R9) [[2]](diffhunk://#diff-5704046957bd9ba24cdd4d1146d69c0e17443bd1d4d92c4a2ff9d3056264b62dL50-R51) [[3]](diffhunk://#diff-003963e35578da5a8e1ef8b52caa02424a0565df7566ae3327e9e99a613fec01L11-R14) [[4]](diffhunk://#diff-003963e35578da5a8e1ef8b52caa02424a0565df7566ae3327e9e99a613fec01L30-R30) [[5]](diffhunk://#diff-7d0dc6982308ef7730dab14bd89da64cd6d4f45b8c65f20eef7b86a93170b506L35-R35) [[6]](diffhunk://#diff-fcb2984284065083e274f2ef06822efb36710e6d5d12a6dfb45dfe25ef7e6b55L35-R35) [[7]](diffhunk://#diff-76acc8b449149da93e8d49a31c46882a98a43e04f9f28748ecc352d562f7f5a6L33-R33) [[8]](diffhunk://#diff-cdf3871194e311e0386a81a41cb29ba0593ee76ed9d6e469107d06dc92d37838L178-R178) [[9]](diffhunk://#diff-00df895537c15d5cf0cd965540e29282391873fd6e21f4883dda51300b54642eL13-R13) [[10]](diffhunk://#diff-596b51d05b25bc0f7b63fef1050031fa66b9b1dd4d3088d2ad62fc28f64e7e53L49-R49)

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [ ] **Required** - I have run my changes through Grammarly
- [ ] If pages have been moved, I have created redirects in `mkdocs.yml`
