### PR TITLE
docs: add Coordinated Asset Launches use case to NTT overview

### DIFF
--- a/docs/products/token-transfers/native-token-transfers/overview.md
+++ b/docs/products/token-transfers/native-token-transfers/overview.md
@@ -72,6 +72,11 @@ Here's a breakdown of the key steps involved when deploying NTT:
     - **[Native Token Transfers](/docs/products/token-transfers/native-token-transfers/get-started/)**: Transfers staked assets natively between networks.
     - **[Messaging](/docs/products/messaging/overview/)**: Moves staking rewards and governance signals across chains.
 
+- **Coordinated Asset Launches**
+
+    - **[Native Token Transfers](/docs/products/token-transfers/native-token-transfers/get-started/)**: Delivers canonical tokens to the destination chain from day one.
+    - **[Sunrise](https://www.sunrisedefi.com/){target=\_blank}**: Coordinates bridging, liquidity seeding, and DEX integration on top of NTT so assets arrive tradable across major venues immediately.
+
 ## Next Steps
 
 Follow these steps to get started with NTT:


### PR DESCRIPTION
## Summary
- Adds a new **Coordinated Asset Launches** use case to the NTT Overview page's Use Cases section
- Highlights how NTT delivers canonical tokens from day one and how Sunrise coordinates bridging, liquidity seeding, and DEX integration on top of NTT

## Test plan
- [ ] Verify the new bullet renders correctly on the NTT Overview page
- [ ] Confirm the Sunrise external link opens in a new tab