### PR TITLE
Update package versions for wormhole-sdk-ts, wormhole, and wormhole-connect

### DIFF
--- a/docs/variables.yml
+++ b/docs/variables.yml
@@ -6,10 +6,10 @@ ntt:
 repositories:
   wormhole_sdk:
     repository_url: https://github.com/wormhole-foundation/wormhole-sdk-ts
-    version: 4.12.0
+    version: 4.13.1
   wormhole:
     repository_url: https://github.com/wormhole-foundation/wormhole
-    version: 2.55.0
+    version: 2.56.0
   native_token_transfers_evm:
     repository_url: https://github.com/wormhole-foundation/native-token-transfers
     version: 2.0.0+evm
@@ -18,7 +18,7 @@ repositories:
     version: 2.0.0+evm
   connect:
     repository_url: https://github.com/wormhole-foundation/wormhole-connect
-    version: 5.0.0
+    version: 5.1.0
   settlement:
     repository_url: https://github.com/mayan-finance/wormhole-sdk-route
     version: 1.26.0

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "4.12.0",
+        "@wormhole-foundation/sdk": "4.13.1",
         "axios": "^1.13.5",
         "sharp": "^0.34.5",
         "swagger-markdown": "^3.0.0"
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@aptos-labs/aptos-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-2.1.0.tgz",
-      "integrity": "sha512-ttdY0qclRvbYAAwzijkFeipuqTfLFJnoXlNIm58tIw3DKhIlfYdR6iLqTeCpI23oOPghnO99FZecej/0MTrtuA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-2.2.0.tgz",
+      "integrity": "sha512-lYgHI8ehgD+Ykhix0IwzLaTCknHp1KNmExbq2bPZk8IeTwQg79D5BOkD46MjW0jGbJbl+J/RBtVF9vM7Te/hWA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"
@@ -147,6 +147,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-2.0.1.tgz",
       "integrity": "sha512-k39Ks+qNcWxWujQrixMaV3ZIO8G9/qzIpDuV7+Td12GWNxXxKze5BqD6pFI3Q1iwI4mw65v1yxTi/jt5ted39Q==",
+      "deprecated": "This version is deprecated, please upgrade to 5.2.1, or the latest version",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/aptos-cli": "^1.0.2",
@@ -1373,9 +1374,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.18.3.tgz",
-      "integrity": "sha512-2hkJrAZvGADMPZBvf6yCu8mHAR6y15VL0pARP/5PUYd9kI5nHyNVr32MhrBFEH3wqKZgQaWG5nAqx+ORgg3zqA==",
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.18.8.tgz",
+      "integrity": "sha512-SXe6bCXNvKcjJwKrRRMX6CBX7/Td4P0PHmMGAFbYzneYTMQpeP4XWDy0OxiXoxnHtT0YF2cHQBTSL2hdOyO1rg==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1386,6 +1387,7 @@
       "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
       "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -1412,9 +1414,9 @@
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts-v2": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.18.1.tgz",
-      "integrity": "sha512-INwA+qAKk4j/zgjSWJ4DDYq3jsTpXmo4YWj4kPfJ5s3uxBDCpgwgYbv5YA/WHjt7bEmgHFMr76ElYGFKZwWkqA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.18.6.tgz",
+      "integrity": "sha512-RknQB7tDQKDXGuQw/oGGoG95X7D+Hrwj9wcgDo4n22W9dnJsHqdWx+wUJgrvezGmmQBr9jvbcGRj+yPJw6E21g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1434,12 +1436,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.18.3.tgz",
-      "integrity": "sha512-FBvyDOM4NsFKBJZHNEcaDhGz1zBsovXctmc/MOduwv/1GkMdvyClNH1EwVWfYWtDCrz/3k83Kizm37sQ5+5ZJA==",
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.18.8.tgz",
+      "integrity": "sha512-VTh9cKPfFV1Zd4WXspAnEeRt7ENmdQf5pApeJkRpgBNxkZpInSwe/hQhMKi4EDPPF7TaMATg9VOn4wxRorI3fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "1.18.3"
+        "@injectivelabs/ts-types": "1.18.8"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts-v2": {
@@ -1454,9 +1456,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.18.3.tgz",
-      "integrity": "sha512-5N4PVlb53aH88hnat4+kzB2Z0Dt107DAHAKg91hNWkwb6bqVBuw9LSXfLS1Y8lhdpdIXn4A8RGxXIaus9MvvOQ==",
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.18.8.tgz",
+      "integrity": "sha512-ouIQMzdY39cd1/jOlr8+jz8kywA0o5tlL2m+GJEtcek2wgBZH7Gsn/5oiANcFoxsIVggABTEnek9k7UYIim4Tg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.33.0",
@@ -1464,16 +1466,16 @@
         "@cosmjs/stargate": "0.33.0",
         "@injectivelabs/abacus-proto-ts-v2": "1.17.4",
         "@injectivelabs/core-proto-ts-v2": "1.18.0",
-        "@injectivelabs/exceptions": "1.18.3",
+        "@injectivelabs/exceptions": "1.18.8",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts-v2": "1.18.1",
+        "@injectivelabs/indexer-proto-ts-v2": "1.18.6",
         "@injectivelabs/mito-proto-ts-v2": "1.17.3",
-        "@injectivelabs/networks": "1.18.3",
+        "@injectivelabs/networks": "1.18.8",
         "@injectivelabs/olp-proto-ts-v2": "1.17.6",
-        "@injectivelabs/ts-types": "1.18.3",
-        "@injectivelabs/utils": "1.18.3",
+        "@injectivelabs/ts-types": "1.18.8",
+        "@injectivelabs/utils": "1.18.8",
         "@noble/curves": "^1.9.0",
         "@noble/hashes": "^1.8.0",
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1668,20 +1670,20 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.18.3.tgz",
-      "integrity": "sha512-a47BYWbXxtI4uJ3CdfzxH+XHKDOyfIcAA2w+xTuEvq+FUlC1H4n49AyM2Q9V12li6FS1s4Aw+aF0ehAnKcBFgQ==",
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.18.8.tgz",
+      "integrity": "sha512-6P+abdWhoH7v40aUI3dvWHhrDXDvzyRqbSLFJOd6N94W8Ihiv5z12wPhOsTJsqTR2fxP6uOUuDz/jnPt/bHNqQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.18.3.tgz",
-      "integrity": "sha512-mIKHlkqvEAsHwQWnKecqvCdsvpROHA5svP5HeyB1Sp90N26xbnLfLGrVJbl8dGrECyd9/fxDpqd08Gop7rfSPg==",
+      "version": "1.18.8",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.18.8.tgz",
+      "integrity": "sha512-LLzVG08fvumUczzQtcSp16Yb+G3i/IcDXbMinuXszECynDI0tT6ICvNLt3kn8d8GwWpUmxiNraD113wz8w8naA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "1.18.3",
-        "@injectivelabs/networks": "1.18.3",
-        "@injectivelabs/ts-types": "1.18.3",
+        "@injectivelabs/exceptions": "1.18.8",
+        "@injectivelabs/networks": "1.18.8",
+        "@injectivelabs/ts-types": "1.18.8",
         "axios": "^1.13.2",
         "bignumber.js": "^9.3.1",
         "http-status-codes": "^2.3.0",
@@ -1981,7 +1983,6 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2097,6 +2098,7 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -2125,17 +2127,17 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.3.tgz",
-      "integrity": "sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==",
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.5.tgz",
+      "integrity": "sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A==",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
-        "@types/uuid": "^8.3.4",
+        "@types/uuid": "^10.0.0",
         "@types/ws": "^8.2.2",
         "buffer": "^6.0.3",
         "eventemitter3": "^5.0.1",
-        "uuid": "^8.3.2",
+        "uuid": "^11.0.0",
         "ws": "^8.5.0"
       },
       "funding": {
@@ -2144,7 +2146,7 @@
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": "^6.0.0"
       }
     },
     "node_modules/@solana/web3.js/node_modules/superstruct": {
@@ -2154,6 +2156,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@solana/web3.js/node_modules/ws": {
@@ -2239,7 +2254,6 @@
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -2259,7 +2273,6 @@
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -2280,8 +2293,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2294,7 +2306,6 @@
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2319,15 +2330,14 @@
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -2340,55 +2350,56 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.12.0.tgz",
-      "integrity": "sha512-YHLnfFBXjQXdGxsqObZgbbYIKXnz7NFVaiN1picsZu1DWn7EFbhs36f21cSma13POf2d14GCNBdoTAkgS0Y9fw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.13.1.tgz",
+      "integrity": "sha512-H0P9/0lNWcPvtb2lEioeZTfuwMlr19Wop8kwrjis1MFT1gDKLTM/NHvWgU6Vx1tXaDDgAyBdQx/0x2SrvlSM4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.12.0",
-        "@wormhole-foundation/sdk-algorand-core": "4.12.0",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-aptos": "4.12.0",
-        "@wormhole-foundation/sdk-aptos-cctp": "4.12.0",
-        "@wormhole-foundation/sdk-aptos-core": "4.12.0",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-base": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-definitions": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
-        "@wormhole-foundation/sdk-evm-cctp": "4.12.0",
-        "@wormhole-foundation/sdk-evm-core": "4.12.0",
-        "@wormhole-foundation/sdk-evm-portico": "4.12.0",
-        "@wormhole-foundation/sdk-evm-tbtc": "4.12.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-solana": "4.12.0",
-        "@wormhole-foundation/sdk-solana-cctp": "4.12.0",
-        "@wormhole-foundation/sdk-solana-core": "4.12.0",
-        "@wormhole-foundation/sdk-solana-tbtc": "4.12.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-stacks": "4.12.0",
-        "@wormhole-foundation/sdk-stacks-core": "4.12.0",
-        "@wormhole-foundation/sdk-sui": "4.12.0",
-        "@wormhole-foundation/sdk-sui-cctp": "4.12.0",
-        "@wormhole-foundation/sdk-sui-core": "4.12.0",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "4.12.0",
-        "@wormhole-foundation/sdk-xrpl": "4.12.0"
+        "@wormhole-foundation/sdk-algorand": "4.13.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.13.1",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-aptos": "4.13.1",
+        "@wormhole-foundation/sdk-aptos-cctp": "4.13.1",
+        "@wormhole-foundation/sdk-aptos-core": "4.13.1",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-base": "4.13.1",
+        "@wormhole-foundation/sdk-btc": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-definitions": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-evm-cctp": "4.13.1",
+        "@wormhole-foundation/sdk-evm-core": "4.13.1",
+        "@wormhole-foundation/sdk-evm-portico": "4.13.1",
+        "@wormhole-foundation/sdk-evm-tbtc": "4.13.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-solana": "4.13.1",
+        "@wormhole-foundation/sdk-solana-cctp": "4.13.1",
+        "@wormhole-foundation/sdk-solana-core": "4.13.1",
+        "@wormhole-foundation/sdk-solana-tbtc": "4.13.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-stacks": "4.13.1",
+        "@wormhole-foundation/sdk-stacks-core": "4.13.1",
+        "@wormhole-foundation/sdk-sui": "4.13.1",
+        "@wormhole-foundation/sdk-sui-cctp": "4.13.1",
+        "@wormhole-foundation/sdk-sui-core": "4.13.1",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-xrpl": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.12.0.tgz",
-      "integrity": "sha512-0izkqRrUyUGsAI9GArKhY5b9R6+8jgzKcjt+R7UX+IkZ99Efjujy+UR54UY1noc2hd5RB7fDfV0DHzE2dOycXQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.13.1.tgz",
+      "integrity": "sha512-E7ZItZrddQ8yOUG3rPJ2J4U0Gs9VfzYQ1Omx5Mv8nYxzSbGxU7/au8yZ++iTJNUH5S6jmJHCrkkvBikgE0d45g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2396,103 +2407,115 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.12.0.tgz",
-      "integrity": "sha512-smQM1w9/qBUFJFmwSdgHQ+Y6F0LYzQX25ZlgKesfyL+C3E6eQUlZSOCSpaVorUDoZR41sh85rYMiAeoAH/3lKQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.13.1.tgz",
+      "integrity": "sha512-y9I3Jt3AsTVbBNbO2Pd9LKQnlaG1/etzKi6Se2bcOS9JlD/muILKubLhmafLgqi13OUQb7bfdlARrfI7/dXW9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-algorand": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-YonFcSErw/cPafJfTJi7xOCnr0Kj6EED9pekUlcQZmv0z2q8gFRPwMBSNb7DkodDXQEETutZVkubunNqEyMagA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-1VEcWdb9khdbD8fl2FlD4285cYzR3XkaZNyfbU+1qtmQ4Us+Xyjg138ESHO/2E+MRaVCtfi0lNvzvhbKs+LkYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.12.0",
-        "@wormhole-foundation/sdk-algorand-core": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-algorand": "4.13.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.12.0.tgz",
-      "integrity": "sha512-esHbW41webUnCQhnMJRR7NBjGbtgvKliROiVn+puPumgtkDx9kdnEUo5AVoNgTdZHn61q+c5UNtlTqVTKsH78w==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.13.1.tgz",
+      "integrity": "sha512-7U04rkmhwvZts26hGiROblNazKKI+W30p4UHdiHg5Tiqql9tEj05xGaH2zHhWzg5vd8W4IPBFA79JfeKclQvtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.12.0.tgz",
-      "integrity": "sha512-287Hk9iDi2L25QKRSNDHKZylwtgMgYOb1foPx70ZOoQBu/FVG0vMhEANFXoiqjdxwVKpLdYTKS2VYhsvLnCiAw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.13.1.tgz",
+      "integrity": "sha512-k+GU8ti4q5umq8iVW8mv6wLXHRd7PuGfT1Jo9i5EYcamq2+fx9z0TVQIgKUajYhc3nxin5VKcxnqYKCWt4xGYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-aptos": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.12.0.tgz",
-      "integrity": "sha512-RzuJvZVhF7YiqttAXo+j79Ir1diOm1Bg3gJgoS9AsCZBvd4wVYz/t9zytVCIBXKrkuapYNf38yzyCMQCT0IwBQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.13.1.tgz",
+      "integrity": "sha512-UvIB9DmtTHQ8/SkwOiDvHodyozO12vNHq8zydS0K6AB3UUcdjoThqvjhMCGE68wkvipsnHZ9jKWlsZcDQuvY1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-aptos": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-gXww+zSyHqiWBAgFHLZoize7F4bUTbD0hgtqsq23ZpNRGwk4E0kG2b56t6lfso/aYOwLcYb03DaOMssOGklvJA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-3moAOYLUjisuhIn8pErd+GneWZibMZmU18XfXogynAKyYB2kglG+Gmh7uz6aXhA2ePk8k/K59IrmJ05weTPBqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.12.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-aptos": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.12.0.tgz",
-      "integrity": "sha512-3HOmEWuhPhFVxtxBDe+OZc+8Bz9p98EBJS8YpriToiT4/Z36EKCtl40A08RqWx91jtq4cJ7ipZxP6TNSr5P/kA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.13.1.tgz",
+      "integrity": "sha512-oXZ3Dj7DlnhdHlAfMa4TAMTWRy7nz/FU7hT1/9Nl2v0TwTl2UX2U7u266sboEb4C6damMcMRjXR2P5hDcytw4w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.12.0.tgz",
-      "integrity": "sha512-uNPPkOsW2VqEfaMWKs8OYsHfmmkToix/ZOP+X5lC6DdGo3gkYNf5jMv9J7sn1V3mEpyWpy6HyF6uO/jFxEQ22A==",
+    "node_modules/@wormhole-foundation/sdk-btc": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-btc/-/sdk-btc-4.13.1.tgz",
+      "integrity": "sha512-5psm/56XIj5z8A69xCekX490qSByGKM/2tM7Dq3wlynNi81XqS9onYOJP63TQn4SG7ZVpeaJTDSbUDuOraPHaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "4.12.0",
-        "@wormhole-foundation/sdk-definitions": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.13.1.tgz",
+      "integrity": "sha512-ZAgoWGIJ4CXCvu01TaBRSZz5rxMpV8DpCbvkun5y9+aZkvsOuV98R3Se3gglpXQYc7kTrbWagjmFo2xsOXOplA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "4.13.1",
+        "@wormhole-foundation/sdk-definitions": "4.13.1",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2500,16 +2523,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.12.0.tgz",
-      "integrity": "sha512-U0nonSHDGv8nclhp/7Bszubw55FEedZSaNikJFY0J8dIYyTycJRXUTnYn/wUpC2qnKLsO2qkZp90OjI9IsMdsw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.13.1.tgz",
+      "integrity": "sha512-NQaSmMeZEwf6h6NYS638DC8RfMzEvAEt8b/a/YvD5HME+ILRrKh9iLEbwboHENDHhYGC03msDJfrXga1hnuydQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2517,33 +2540,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.12.0.tgz",
-      "integrity": "sha512-Si/h8xLxymEQieBt1ocLx6Voc1YT/aH3Zd7DuBH9vue3lkoPp/SJ6hKo87AhIGPjxImR+H7l2zj5jjYlmLy0dw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.13.1.tgz",
+      "integrity": "sha512-8614HBvVMLa90eeW2kDzMWAPHVXibEjgrel7k7N/Kszq/C+8pUimtDXd+4JW5eMuYr8H/6xVxcsKludxHRu0NA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.12.0.tgz",
-      "integrity": "sha512-Ch3XA14pZ7ZN69Go8REmJ2A0AOAiBiF+7qj2AGSqejjMyze6/AneJ0j+yrYQV3qIff3K90X5h8TSFyEfRvSQ2Q==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.13.1.tgz",
+      "integrity": "sha512-IwjbPgFcsJg51Iex1ntahRzflBhWNVyQiRsIijkhtsSY6tmuwNmIDr8Q9M/Kd2/eRRAWlZNCYPh8kgwt1Za0Xw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2551,37 +2574,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-SK/v7+1Ty38g1bru5lFrjkn0oZa1UxNDNDrMoVlAZ+xD78vxkOTJUdFkUb5JdNM+mvrzyB5ImFkypEsqMVdG8g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-LB1QP0IYvBKNXeQrhYnr8wBc2SE6zwcMaqG6Wy5B8/CWY9tHDL3iK9x1Z2AfB/QENgFyc+U1VI5z9a0LkFEChg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-cosmwasm": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.12.0.tgz",
-      "integrity": "sha512-55e12g3h+hWrQw0xJlJaCx1rtbhfiCYLoeSApg5RKReBApkm8WETVsWfcHywqQ7ysja++SJ/2Mpq7rYG3XjbNQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.13.1.tgz",
+      "integrity": "sha512-/8X1q8zgmPTnjql5aoARpZ4jhdYSccx6pFLboVoJIPUSszSWDaMgUvGX2039mCp7KPGdV8SNMVrAPtR47ipZFA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "4.12.0"
+        "@wormhole-foundation/sdk-base": "4.13.1"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.12.0.tgz",
-      "integrity": "sha512-lHD2yAm77Xas2kMBokquP5li0LkbnBFrIhSRSeWU1d3Gj+P1DSnQJVOJ0NL/qVeQc6Sb7FguSfV1xjjMP+Jusw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.13.1.tgz",
+      "integrity": "sha512-24jrp8cH9Nlc1laN/TGihOiGkUjlYFVUNhXklHlsmCuzP0G9/mJKde2k9y/4u8qsgI/d3YxRAVscxADez4NqFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2589,14 +2612,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.12.0.tgz",
-      "integrity": "sha512-HuYKEAX2HVquqPQeSauYqykuYasF5ykB8okeCNdkAhEEhYo3lr/VTAb7mIvOlpQ4moNRc3iYQzJ0GhLvNVZ4ug==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.13.1.tgz",
+      "integrity": "sha512-XWtj6Oj56wL9UDGi1kU1FW6g1lcHNdaYBl9aSTMKOQU/kaEYZA4gEJ0gF5n9v2To+ZD7pGq6NRXQOiXYrzgjqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
-        "@wormhole-foundation/sdk-evm-core": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-evm-core": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2604,13 +2627,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.12.0.tgz",
-      "integrity": "sha512-886fbkq2pwS9qch4PCiFL6E89U6dOBfjI+ozOB7hvKMmI0Wwt7KzEpthvnra30lyYBoME+IwRiuIFg64DnbRww==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.13.1.tgz",
+      "integrity": "sha512-r/FGJYx6r1bhkO29GPG2c0QN0Oy2K+07g2idUWt2RdHWYlkDXgWQmtA04eKgyU5O5jPkXguJu8mA4lrXfyOUMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2618,15 +2641,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.12.0.tgz",
-      "integrity": "sha512-erfg0sVDBvEqdtNaZYSJC6sOeJ3VDmbOx1UNMoxCB67I0NSBPkYnamjj3cWOV34YSP+5GrKosbZA1AE4B8k4sA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.13.1.tgz",
+      "integrity": "sha512-Hs0slWmdcn74nzS3vlaNNPE38opaZew9CvMi476YdOCv6UNUIMTqQiYbJERTiI7X9d7BS+w3CVmORg5njMkwww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
-        "@wormhole-foundation/sdk-evm-core": "4.12.0",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-evm-core": "4.13.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2634,14 +2657,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.12.0.tgz",
-      "integrity": "sha512-i7fMVeiQILGGoQD2X/tDV8RdRwxoRZhjkCd414Mhqi0i0lSvdzgIC1o6nF+7PUjsQGVWA+ROH7uu6sUx7JoI1w==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.13.1.tgz",
+      "integrity": "sha512-tj7Ak8m/F3t/B5iWTYGuOMWvSGuum6G1su/NX9w1q3FJvfDRnQXwsZVyw/byCRY7Ovd80PNFNnJlHo1/wpPE9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
-        "@wormhole-foundation/sdk-evm-core": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-evm-core": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2649,14 +2672,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-eoKPYQPQx0oUFCz5zka4G1pKYUnA/rbwTXDtKDw13E8xRsGp9kVH+1v+QOTLaYlxSD8HlVEjbw8zi4gY8AbWJg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-ctHwgjhC4k9YpSPPwbtvrifmI8gPr2rHsTS9yol5c1iHXKuaYV8TSyFJbJriRYb31Mf8sqeODSDHfTNSrz2GUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-evm": "4.12.0",
-        "@wormhole-foundation/sdk-evm-core": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-evm-core": "4.13.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2664,16 +2687,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.12.0.tgz",
-      "integrity": "sha512-CJp/zu0P5HsgUo+vkKhzM70Dpqj0tOTg7pwVxRsug5fTgjKh2FFuVoOcmSMYxTPOWE19M00udUJu9/9uLdDvbw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.13.1.tgz",
+      "integrity": "sha512-9gV8qQaEXHYd+WbCx9wn1ZcPslfKGAewV06llrtaLPCTGq1vPA0lPPyeNeEwwrIHsv8aNFABF+Vm17eKWnK1TA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2681,162 +2704,162 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.12.0.tgz",
-      "integrity": "sha512-9Xr0yg0hoGf7HrM35fHLtfv5AA0asErH+64uyb6/XX4GkrvS79Pn/HZ1lGrGpXn1vrZ2vTfAsRUOOIedNI/1Qg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.13.1.tgz",
+      "integrity": "sha512-N7jGhD3Fwt9ZKBgx01YOGKPJJyU9jmgP+GdyBG8LVFWhmki1VcKAs7AoijYyWmsUcuSjI2PuvmRvc3wLP0K8aQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-solana": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-solana": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.12.0.tgz",
-      "integrity": "sha512-9Sv0nIOTRa1PdA7ioj3A88IvZIuara3gYpgxzJ8bGCwpFEYBXYQrZISPSDbD6cPaKFsYW0fekk/2PVPPOdARDg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.13.1.tgz",
+      "integrity": "sha512-gcOvdKxMip2uKcgOHgUNH4NuWkw65XPC4hCn84COoglTx0NCQ4XfZARSy16Q14CzQqh/J+xSIpdFk7ER22oB0w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-solana": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-solana": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.12.0.tgz",
-      "integrity": "sha512-cXCw/t0rbd9sUppJ0REl4E1qXPkAqeYyu6wsfGQ+1wTDP+1aKB7hd57gUZcx96TdsTQC/ZU4ZAeh/sGsmyf+zA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.13.1.tgz",
+      "integrity": "sha512-LrqmizRQ7wMstOudGDG/5Bhoeafy9fCk4Fsid/NQ3XKuY+ckvHR9HJUIEvG9Gi/8SdQ3+my8qyXoRAYap7AkpA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-solana": "4.12.0",
-        "@wormhole-foundation/sdk-solana-core": "4.12.0",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-solana": "4.13.1",
+        "@wormhole-foundation/sdk-solana-core": "4.13.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-3yEa2qb3WZWljdAr9ouLKMN2FsYlqwsnQnY9WMAJ8HBtJzZVs2+dBBogJ9OAanHtjmxeYHeCeJrkkGfLGTOVCg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-jhMVoPxQhmwqvdovqGcZ704+5+ajdRkr+tS6qOZeCwHK6wyBwYjS9sMGRiMyDKuOA2CZ0HpDU4BP6lmzGpd3wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-solana": "4.12.0",
-        "@wormhole-foundation/sdk-solana-core": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-solana": "4.13.1",
+        "@wormhole-foundation/sdk-solana-core": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.12.0.tgz",
-      "integrity": "sha512-OnBTX7jiYZ6Q5FZWYgl1DOeb1QEgPLGRdgT2VgGdJqtDRkDhPHG6cjVboliarpYz78I+mn21moVLrKBdF4Q9xA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.13.1.tgz",
+      "integrity": "sha512-ptFhvojQgn/6v+0RMDHj7ti7gz22jiHEKrmtkrANj/PTQDRxzt7tk3w3pBOpClBuZLds/iLkpFyGVCuQKeiU/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stacks/network": "^7.0.2",
         "@stacks/transactions": "^7.1.0",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.12.0.tgz",
-      "integrity": "sha512-PBqaTGACGxuTBbNQsmjMeKscoO8QL47kCVdgsnxZ+MWh+yefKZwgjUC6tvvCIG7Oba//du8KPIaIks6eLJx2aQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.13.1.tgz",
+      "integrity": "sha512-ABdTqKkTELiabyLDX1hNDdpFBw15igOPECVw5jqT9VyzVOZQoqJYIB2RASqDWWN0eqVenKmraYdiCh8z0pjKLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-stacks": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-stacks": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.12.0.tgz",
-      "integrity": "sha512-4MjpCnsogKw1BB7gAggXmSXrrga5H+W92Lbu3pg6Fjcn7vNDFUDTvX+9AGqlvkFhA2hTHIb5bxBZ20hSEiJ0VQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.13.1.tgz",
+      "integrity": "sha512-GHXSrx6LTLjsqVrNvmvT3Tq6DbSuvsG5MvSlPC7MLC/W0cTVsm2dq5h0lbswLc66WzM4y0AT7knlo+hZL0aTIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.12.0.tgz",
-      "integrity": "sha512-PUHMptK3jEmNJXnj9KBh8hMsCVKq1wRkgzqKusUDh6sUbSK1W/PuFV9LiohHT8eMFZUTJpU3Jn5L8z5MhFsU2w==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.13.1.tgz",
+      "integrity": "sha512-4SF/tCqPQxK8wnGQmFl28sqt8HdHm5nBCZYeVI+bdtz8KcnBt4B7viG3DQ2T14eqdpVlTc+6GhggDqNx8kMtSA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-sui": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-sui": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.12.0.tgz",
-      "integrity": "sha512-1rJJJbeR2eEuw/W1C7CMUMxw4P7BSlGzuvU9SNYLe/hv1FCayDTwyBP09lVgaKwjnYuJ10GPjzSQPSgarTa36g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.13.1.tgz",
+      "integrity": "sha512-lFR0IuO0EJssv3bJ1+lB+2x+QkOt96md5G+lt/Qbeq2WUEOnk9LTu35oVXdHI9Njzv3Z0JkxPvRzjDuOYkWU4A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-sui": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-sui": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.12.0.tgz",
-      "integrity": "sha512-81o4k3xvzj6HgsvIxyHFhQOHqx/1tT6/1m7PmhKBBTglepKdYsIzrZO8a1+ZYRzFA2nK0Fsb3o4m96isI2pqkw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.13.1.tgz",
+      "integrity": "sha512-0+h2TyTylUUiS3u9OephDlEUKy4XMWMqrzgeuM9znnxqZOlI+7ZfR5VJ82ucN1IygFdoikFDxmiPBTptSwJbxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.12.0",
-        "@wormhole-foundation/sdk-sui": "4.12.0",
-        "@wormhole-foundation/sdk-sui-core": "4.12.0"
+        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-sui": "4.13.1",
+        "@wormhole-foundation/sdk-sui-core": "4.13.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-xrpl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-xrpl/-/sdk-xrpl-4.12.0.tgz",
-      "integrity": "sha512-/dDgdpROK/1rbFGw9D1UIWKGIvx9de34pbPolnGvfC3jvhLgSL/rEYd8Nam2mgxWdHOEvoYYErGdtzq0CmkXAA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-xrpl/-/sdk-xrpl-4.13.1.tgz",
+      "integrity": "sha512-4JbcVCx8Kqxqn/1Ytugf+J4IduJ0TRdLbdupIIG9mkcIJDvuqYY0/n7apv4tKKwCAQRsQEPF3QaIDeCnSvukhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.12.0",
+        "@wormhole-foundation/sdk-connect": "4.13.1",
         "xrpl": "^4.2.0"
       },
       "engines": {
@@ -2948,6 +2971,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3205,20 +3229,6 @@
         "node": ">=4.5"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/c32check": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
@@ -3243,7 +3253,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -3253,7 +3262,6 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -3359,7 +3367,6 @@
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -3478,7 +3485,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -3494,7 +3500,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3507,7 +3512,6 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -3714,7 +3718,6 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4134,7 +4137,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -4254,10 +4256,11 @@
       }
     },
     "node_modules/graphql": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
-      "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
+      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -4387,8 +4390,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4415,7 +4417,6 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -4636,8 +4637,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4665,7 +4665,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -4725,7 +4724,6 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4842,7 +4840,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4953,7 +4950,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4988,7 +4984,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4997,12 +4992,13 @@
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ox": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.4.tgz",
-      "integrity": "sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
+      "integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
       "funding": [
         {
           "type": "github",
@@ -5061,7 +5057,6 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5227,11 +5222,10 @@
       "license": "MIT"
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5242,7 +5236,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5269,8 +5262,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -5287,7 +5279,6 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -5674,6 +5665,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5697,20 +5689,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -5746,9 +5724,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.46.3",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.46.3.tgz",
-      "integrity": "sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==",
+      "version": "2.47.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.2.tgz",
+      "integrity": "sha512-etDIwDgmDiGaPg8rUbJtUFuC3/nAJCbhMYyfh5dOcqNNkzBWTNcS2VluPSM5JVo+9U3b2hle2RkBEq3+xyvlvg==",
       "funding": [
         {
           "type": "github",
@@ -5763,7 +5741,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.12.4",
+        "ox": "0.14.0",
         "ws": "8.18.3"
       },
       "peerDependencies": {
@@ -5860,14 +5838,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "4.12.0",
+    "@wormhole-foundation/sdk": "4.13.1",
     "axios": "^1.13.5",
     "sharp": "^0.34.5",
     "swagger-markdown": "^3.0.0"


### PR DESCRIPTION
## Summary

- **wormhole-sdk-ts**: 4.12.0 → 4.13.1 (`docs/variables.yml`, `scripts/package.json`, `scripts/package-lock.json`)
- **wormhole**: 2.55.0 → 2.56.0 (`docs/variables.yml`)
- **wormhole-connect**: 5.0.0 → 5.1.0 (`docs/variables.yml`)

All doc version references use template variables from `variables.yml`, so updating that single file propagates the correct versions across the entire documentation site.

Closes #828, closes #830, closes #831, closes #832, closes #834

## Test plan

- [ ] Verify the docs site builds successfully with the updated versions
- [ ] Spot-check pages that reference SDK/Connect versions render the new values
- [ ] Confirm `scripts/` tooling runs correctly with the updated SDK dependency