### PR TITLE
docs: add Wormhole Connect executor migration guide

### DIFF
--- a/docs/protocol/infrastructure/relayers/executor-vs-sr.md
+++ b/docs/protocol/infrastructure/relayers/executor-vs-sr.md
@@ -95,6 +95,43 @@ Moving from the Standard Relayer to the Executor model involves changes to how m
 - **Finality and replay protection**: If delivery semantics were previously used for replay safety, choose either sequence-based (finalized consistency only), or hash-based replay protection (any consistency level) and wire `_replayProtect` according to your chosen consistency level.
 - **Fees and refunds**: Refunds, retries, and SLAs are provider policy in the Executor model. Use the provider’s API and signed-quote metadata for observability and error handling.
 
+## Migration for Wormhole Connect Integrators
+
+!!! note
+    If you are using [Wormhole Connect](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank} and currently configure NTT routes with `nttRoutes()`, you should migrate to `nttExecutorRoute()`. The `nttRoutes()` helper bundles both the Manual route and the Executor route, but since the Standard Relayer is being deprecated, the recommended path forward is to use the Executor route explicitly.
+
+**Before** — using `nttRoutes()`:
+
+```typescript
+import { nttRoutes } from '@wormhole-foundation/wormhole-connect';
+
+const config = {
+  routes: [
+    ...nttRoutes({
+      tokens: { /* your token config */ },
+    }),
+  ],
+};
+```
+
+**After** — using `nttExecutorRoute()`:
+
+```typescript
+import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';
+
+const config = {
+  routes: [
+    nttExecutorRoute({
+      ntt: {
+        tokens: { /* your token config */ },
+      },
+    }),
+  ],
+};
+```
+
+The `nttExecutorRoute` provides one-click transfers powered by the Executor, with support for native gas drop-off and referrer fees. For a complete working example, see the [NTT Connect demo](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}.
+
 ## Next Steps
 
 The resources below provide deeper technical detail and example implementations. 

--- a/docs/protocol/infrastructure/relayers/executor-vs-sr.md
+++ b/docs/protocol/infrastructure/relayers/executor-vs-sr.md
@@ -54,7 +54,7 @@ Replay protection works very differently between the two models, especially depe
 
 **Standard Relayer**
 
-The Standard Relayer enforces an “execute only once” guarantee at the delivery layer. Applications do not implement custom replay protection — the relayer ensures each request is executed exactly once.
+The Standard Relayer enforces an “execute only once” guarantee at the delivery layer. Applications do not implement custom replay protection - the relayer ensures each request is executed exactly once.
 
 **Executor**
 
@@ -98,9 +98,9 @@ Moving from the Standard Relayer to the Executor model involves changes to how m
 ## Migration for Wormhole Connect Integrators
 
 !!! note
-    If you are using [Wormhole Connect](https://github.com/wormhole-foundation/wormhole-connect){target=\_blank} and currently configure NTT routes with `nttRoutes()`, you should migrate to `nttExecutorRoute()`. The `nttRoutes()` helper bundles both the Manual route and the Executor route, but since the Standard Relayer is being deprecated, the recommended path forward is to use the Executor route explicitly.
+    If you are using [Wormhole Connect](/docs/products/connect/overview/){target=\_blank} and currently configure NTT routes with `nttRoutes()`, you should migrate to `nttExecutorRoute()`. The `nttRoutes()` helper bundles both the Manual route and the Executor route, but since the Standard Relayer is being deprecated, the recommended path forward is to use the Executor route explicitly.
 
-**Before** — using `nttRoutes()`:
+**Before** - using `nttRoutes()`:
 
 ```typescript
 import { nttRoutes } from '@wormhole-foundation/wormhole-connect';
@@ -114,7 +114,7 @@ const config = {
 };
 ```
 
-**After** — using `nttExecutorRoute()`:
+**After** - using `nttExecutorRoute()`:
 
 ```typescript
 import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';


### PR DESCRIPTION
## Summary
- Adds a "Migration for Wormhole Connect Integrators" section to the [executor-vs-sr](https://wormhole.com/docs/protocol/infrastructure/relayers/executor-vs-sr/) page
- Provides before/after code snippets showing migration from `nttRoutes()` to `nttExecutorRoute()`
- Links to the [demo-ntt-connect](https://github.com/wormhole-foundation/demo-ntt-connect) repo as a working reference

## Test plan
- [ ] Verify the page renders correctly with `mkdocs serve`
- [ ] Confirm code snippets display properly
- [ ] Verify the external links resolve