### PR TITLE
docs: migrate nttRoutes to nttExecutorRoute across Connect docs

### DIFF
--- a/docs/.snippets/code/products/connect/configuration/data/configure-ntt.tsx
+++ b/docs/.snippets/code/products/connect/configuration/data/configure-ntt.tsx
@@ -1,5 +1,5 @@
 import WormholeConnect, { type config } from '@wormhole-foundation/wormhole-connect';
-import { nttRoutes } from '@wormhole-foundation/wormhole-connect/ntt';
+import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';
 
 const wormholeConfig: config.WormholeConnectConfig = {
   network: 'Testnet',
@@ -13,32 +13,34 @@ const wormholeConfig: config.WormholeConnectConfig = {
     },
   },
   routes: [
-    ...nttRoutes({
-      tokens: {
-        WSV_NTT: [
-          {
-            chain: 'Solana',
-            manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
-            token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
-            transceiver: [
-              {
-                address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
-                type: 'wormhole',
-              },
-            ],
-          },
-          {
-            chain: 'BaseSepolia',
-            manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
-            token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
-            transceiver: [
-              {
-                address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
-                type: 'wormhole',
-              },
-            ],
-          },
-        ],
+    nttExecutorRoute({
+      ntt: {
+        tokens: {
+          WSV_NTT: [
+            {
+              chain: 'Solana',
+              manager: 'nMxHx1o8GUg2pv99y8JAQb5RyWNqDWixbxWCaBcurQx',
+              token: '2vLDzr7hUpLFHQotmR8EPcMTWczZUwCK31aefAzumkmv',
+              transceiver: [
+                {
+                  address: 'AjL3f9FMHJ8VkNUHZqLYxa5aFy3aTN6LUWMv4qmdf5PN',
+                  type: 'wormhole',
+                },
+              ],
+            },
+            {
+              chain: 'BaseSepolia',
+              manager: '0xaE02Ff9C3781C5BA295c522fB469B87Dc5EE9205',
+              token: '0xb8dccDA8C166172159F029eb003d5479687452bD',
+              transceiver: [
+                {
+                  address: '0xF4Af1Eac8995766b54210b179A837E3D59a9F146',
+                  type: 'wormhole',
+                },
+              ],
+            },
+          ],
+        },
       },
     }),
   ],

--- a/docs/.snippets/code/products/connect/configuration/data/example-all-routes.ts
+++ b/docs/.snippets/code/products/connect/configuration/data/example-all-routes.ts
@@ -1,14 +1,14 @@
 import WormholeConnect, {
   DEFAULT_ROUTES,
-  nttRoutes,
   MayanRouteSWIFT,
   type config,
 } from '@wormhole-foundation/wormhole-connect';
+import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';
 
 import { myNttConfig } from './consts'; // Custom NTT configuration
 
 const config: config.WormholeConnectConfig = {
-  routes: [...DEFAULT_ROUTES, ...nttRoutes(myNttConfig), MayanRouteSWIFT],
+  routes: [...DEFAULT_ROUTES, nttExecutorRoute({ ntt: myNttConfig }), MayanRouteSWIFT],
 };
 
 <WormholeConnect config={config} />;

--- a/docs/products/connect/configuration/data.md
+++ b/docs/products/connect/configuration/data.md
@@ -66,7 +66,7 @@ The `@wormhole-foundation/wormhole-connect` package offers a variety of `route` 
 - **`DEFAULT_ROUTES`**: Array containing the four preceding routes (`TokenBridgeRoute`, `AutomaticTokenBridgeRoute`, `CCTPRoute`, `AutomaticCCTPRoute`).
 - **[`nttAutomaticRoute(nttConfig)`](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sdk/route/src/automatic.ts){target=\_blank}**: Function that returns the automatically-redeemed (relayed) Native Token Transfer (NTT) route.
 - **[`nttManualRoute(nttConfig)`](https://github.com/wormhole-foundation/native-token-transfers/blob/main/sdk/route/src/manual.ts){target=\_blank}**: Function that returns the manually-redeemed NTT route.
-- **`nttRoutes(nttConfig)`**: Function that returns both NTT routes as an array.
+- **`nttExecutorRoute(nttConfig)`**: Function that returns the Executor-powered NTT route for one-click transfers.
 - **[`MayanRoute`](https://github.com/mayan-finance/wormhole-sdk-route/blob/main/src/index.ts#L57){target=\_blank}**: Route that offers multiple Mayan protocols.
 - **[`MayanRouteSWIFT`](https://github.com/mayan-finance/wormhole-sdk-route/blob/main/src/index.ts#L528){target=\_blank}**: Route for Mayan's Swift protocol only.
 - **[`MayanRouteMCTP`](https://github.com/mayan-finance/wormhole-sdk-route/blob/main/src/index.ts#L539){target=\_blank}**: Route for Mayan's MCTP protocol only.
@@ -115,8 +115,8 @@ Connect supports [NTT](/docs/products/token-transfers/native-token-transfers/ove
 
 To enable NTT in your app, follow these steps:
 
- 1. Add NTT routes to the `routes` array by calling `nttRoutes(...)` with your token deployment config using the spread operator. This sets up the route logic for native token transfers.
- 2. Provide token metadata for each of the tokens listed in `nttRoutes` in the [`tokensConfig`](#custom-tokens) object. These entries must include `symbol`, `decimals`, and the `tokenId`.
+ 1. Add the NTT route to the `routes` array by calling `nttExecutorRoute(...)` with your token deployment config. This sets up the Executor-powered route logic for native token transfers.
+ 2. Provide token metadata for each of the tokens listed in `nttExecutorRoute` in the [`tokensConfig`](#custom-tokens) object. These entries must include `symbol`, `decimals`, and the `tokenId`.
 
 ```typescript
 --8<-- 'code/products/connect/configuration/data/configure-ntt.tsx'

--- a/docs/products/connect/guides/upgrade.md
+++ b/docs/products/connect/guides/upgrade.md
@@ -191,7 +191,7 @@ The `@wormhole-foundation/wormhole-connect` package offers a variety of `route` 
     - **`DEFAULT_ROUTES`**: Array containing the four preceding routes (TokenBridgeRoute, AutomaticTokenBridgeRoute, CCTPRoute, AutomaticCCTPRoute).
     - **`nttAutomaticRoute(nttConfig)`**: Function that returns the automatically-redeemed (relayed) Native Token Transfer (NTT) route.
     - **`nttManualRoute(nttConfig)`**: Function that returns the manually-redeemed NTT route.
-    - **`nttRoutes(nttConfig)`**: Function that returns both NTT routes as an array.
+    - **`nttExecutorRoute(nttConfig)`**: Function that returns the Executor-powered NTT route for one-click transfers.
     - **`MayanRoute`**: Route that offers multiple Mayan protocols.
     - **`MayanRouteSWIFT`**: Route for Mayan’s Swift protocol only.
     - **`MayanRouteMCTP`**: Route for Mayan’s MCTP protocol only.
@@ -227,15 +227,15 @@ In this example, Connect is configured with routes for both default protocols (W
 ```typescript
 import WormholeConnect, {
   DEFAULT_ROUTES,
-  nttRoutes,
   MayanRouteSWIFT,
   type config,
 } from '@wormhole-foundation/wormhole-connect';
+import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';
 
 import { myNttConfig } from './consts'; // Custom NTT configuration
 
 const config: config.WormholeConnectConfig = {
-  routes: [...DEFAULT_ROUTES, ...nttRoutes(myNttConfig), MayanRouteSWIFT],
+  routes: [...DEFAULT_ROUTES, nttExecutorRoute({ ntt: myNttConfig }), MayanRouteSWIFT],
 };
 
 <WormholeConnect config={config} />;
@@ -361,7 +361,7 @@ In Connect version 3.0, the `nttGroups` property, which was used to configure Na
 
 Key changes:
 
- - **Removed `nttGroups`**: The `nttGroups` property has been removed from the configuration and is now passed as an argument to the `nttRoutes` function.
+ - **Removed `nttGroups`**: The `nttGroups` property has been removed from the configuration and is now passed as an argument to the `nttExecutorRoute` function.
  - **Direct NTT route configuration**: NTT routes are now defined more explicitly, allowing for a more organized structure when specifying tokens, chains, and managers.
 
 This change simplifies the configuration process by providing a cleaner, more flexible way to handle NTT routes across different chains.
@@ -455,42 +455,44 @@ This change simplifies the configuration process by providing a cleaner, more fl
 
 === "v3.x"
 
-    In v3.0, `nttGroups` has been removed, and the configuration is passed to the NTT route constructor as an argument. The tokens and corresponding transceivers are now clearly defined within the `nttRoutes` configuration.
+    In v3.0, `nttGroups` has been removed, and the configuration is passed to the NTT route constructor as an argument. The tokens and corresponding transceivers are now clearly defined within the `nttExecutorRoute` configuration.
 
     ```typescript
     import WormholeConnect, {
-      nttRoutes,
       type config,
     } from '@wormhole-foundation/wormhole-connect';
+    import { nttExecutorRoute } from '@wormhole-foundation/wormhole-connect/ntt';
 
     const config: config.WormholeConnectConfig = {
       routes: [
-        ...nttRoutes({
-          tokens: {
-            Lido_wstETH: [
-              {
-                chain: 'Ethereum',
-                manager: '0xb948a93827d68a82F6513Ad178964Da487fe2BD9',
-                token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
-                transceiver: [
-                  {
-                    address: '0xA1ACC1e6edaB281Febd91E3515093F1DE81F25c0',
-                    type: 'wormhole',
-                  },
-                ],
-              },
-              {
-                chain: 'Bsc',
-                manager: '0x6981F5621691CBfE3DdD524dE71076b79F0A0278',
-                token: '0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C',
-                transceiver: [
-                  {
-                    address: '0xbe3F7e06872E0dF6CD7FF35B7aa4Bb1446DC9986',
-                    type: 'wormhole',
-                  },
-                ],
-              },
-            ],
+        nttExecutorRoute({
+          ntt: {
+            tokens: {
+              Lido_wstETH: [
+                {
+                  chain: 'Ethereum',
+                  manager: '0xb948a93827d68a82F6513Ad178964Da487fe2BD9',
+                  token: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+                  transceiver: [
+                    {
+                      address: '0xA1ACC1e6edaB281Febd91E3515093F1DE81F25c0',
+                      type: 'wormhole',
+                    },
+                  ],
+                },
+                {
+                  chain: 'Bsc',
+                  manager: '0x6981F5621691CBfE3DdD524dE71076b79F0A0278',
+                  token: '0x26c5e01524d2E6280A48F2c50fF6De7e52E9611C',
+                  transceiver: [
+                    {
+                      address: '0xbe3F7e06872E0dF6CD7FF35B7aa4Bb1446DC9986',
+                      type: 'wormhole',
+                    },
+                  ],
+                },
+              ],
+            },
           },
         }),
         /* other routes */
@@ -498,7 +500,7 @@ This change simplifies the configuration process by providing a cleaner, more fl
     };
     ```
 
-    In this new structure, NTT routes are passed directly through the `nttRoutes` function, with the `token`, `chain`, `manager` and `transceiver` clearly defined for each supported asset.
+    In this new structure, NTT routes are passed directly through the `nttExecutorRoute` function, with the `token`, `chain`, `manager` and `transceiver` clearly defined for each supported asset.
 
 ### Update UI Configuration
 


### PR DESCRIPTION
## Summary
- Updates all current-version references from `nttRoutes()` to `nttExecutorRoute()` across Connect configuration docs and code snippets
- Reflects the recommended Executor-powered route for NTT integrations
- Historical v0.x and v1.x migration tabs left unchanged

## Changed files
- `docs/.snippets/code/products/connect/configuration/data/configure-ntt.tsx`
- `docs/.snippets/code/products/connect/configuration/data/example-all-routes.ts`
- `docs/products/connect/configuration/data.md`
- `docs/products/connect/guides/upgrade.md`

## Test plan
- [ ] Verify pages render correctly with `mkdocs serve`
- [ ] Confirm code snippets display properly in tabbed sections
- [ ] Verify v0.x and v1.x historical tabs are unchanged