### PR TITLE
docs: remove Tally references

### DIFF
--- a/docs/.snippets/text/products/multigov/multigov-timeline.json
+++ b/docs/.snippets/text/products/multigov/multigov-timeline.json
@@ -1,17 +1,12 @@
 [
     {
-        "title": "[Submit an Integration Request with Tally](https://www.tally.xyz/get-started)",
-        "content": "Apply for MultiGov access by submitting your request to Tally.",
-        "icon": ":fontawesome-solid-1:"
-    },
-    {
         "title": "Deploy MultiGov to the Hub and Spoke Chains of Your Choice",
         "content": "**→** [Deploy to EVM chains](/docs/products/multigov/guides/deploy-to-evm/)  \n**→** [Deploy to Solana](/docs/products/multigov/guides/deploy-to-solana/)",
-        "icon": ":fontawesome-solid-2:"
+        "icon": ":fontawesome-solid-1:"
     },
     {
         "title": "[Create a Treasury Management Proposal](/docs/products/multigov/tutorials/treasury-proposal/)",
         "content": "Walk through a real example of creating and executing a cross-chain proposal.",
-        "icon": ":fontawesome-solid-check:"
+        "icon": ":fontawesome-solid-2:"
     }
 ]

--- a/docs/products/multigov/faqs.md
+++ b/docs/products/multigov/faqs.md
@@ -52,12 +52,6 @@ To use MultiGov, your DAO must meet the following requirements:
 
 ## What do I need to set up MultiGov for my project?
 
-Get started by filling out the form below:
-
-https://www.tally.xyz/get-started
-
-Tally will reach out to help get your DAO set up with MultiGov.
-
 To set up testing MultiGov for your DAO, you'll need:
 
 - [Foundry](https://getfoundry.sh/introduction/installation/){target=\_blank} and [Git](https://git-scm.com/downloads){target=\_blank} installed.

--- a/docs/products/multigov/get-started.md
+++ b/docs/products/multigov/get-started.md
@@ -8,7 +8,7 @@ categories: MultiGov
 
 [MultiGov](/docs/products/multigov/overview/){target=\_blank} enables multichain governance using Wormhole messaging. With MultiGov, token holders can create proposals, vote, and execute decisions from any supported chain, eliminating the need to bridge assets or rely on a single governance hub.
 
-This page walks you through the MultiGov deployment flow—from requesting access with Tally to choosing a network and following the appropriate deployment guide.
+This page walks you through the MultiGov deployment flow—from choosing a network to following the appropriate deployment guide.
 
 ## Prerequisites
 
@@ -22,14 +22,6 @@ Before deploying MultiGov, you need a governance token deployed on multiple chai
      - Use an SPL token.
      - Voting eligibility and weight are managed by the [MultiGov staking program](/docs/products/multigov/concepts/architecture/#spoke-solana-staking-program){target=\_blank}.
 
-## Request Tally Access
-
-MultiGov integrations are coordinated through [Tally](https://www.tally.xyz/explore){target=\_blank}, a multichain governance platform that powers proposal creation, voting, and execution.
-
-To get started, fill out the integration [intake form](https://www.tally.xyz/get-started){target=\_blank}. The Tally team will review your application and contact you to discuss deployment and setup requirements.
-
-Once approved, review the deployment flow below to understand the integration process. Then, follow the appropriate deployment guide to integrate MultiGov with your governance token on EVM chains, Solana, or other supported networks.
-
 ## Deployment Flow
 
 MultiGov deployments follow a similar structure on both EVM and Solana. This section provides a high-level overview of the end-to-end flow. Each step is explained in more detail in the platform-specific deployment guides linked [below](#next-steps).
@@ -38,7 +30,7 @@ MultiGov deployments follow a similar structure on both EVM and Solana. This sec
 
 ## Next Steps
 
-You've now completed the initial setup and requested access through Tally. Continue to the deployment guide that matches your governance architecture.
+Continue to the deployment guide that matches your governance architecture.
 
 <div class="grid cards" markdown>
 

--- a/docs/products/multigov/guides/deploy-to-evm.md
+++ b/docs/products/multigov/guides/deploy-to-evm.md
@@ -8,7 +8,7 @@ categories: MultiGov
 
 This guide provides instructions to set up and deploy the MultiGov governance system locally. Before diving into the technical deployment, ensure that MultiGov is the right fit for your project’s governance needs by following the steps for the [integration process](/docs/products/multigov/get-started/){target=\_blank}.
 
-Once your project is approved through the intake process and you’ve collaborated with the Tally team to tailor MultiGov to your requirements, use this guide to configure, compile, and deploy the necessary smart contracts across your desired blockchain networks. This deployment will enable decentralized governance across your hub and spoke chains.
+Once your project is approved through the intake process, use this guide to configure, compile, and deploy the necessary smart contracts across your desired blockchain networks. This deployment will enable decentralized governance across your hub and spoke chains.
 
 ## Prerequisites 
 

--- a/docs/products/multigov/overview.md
+++ b/docs/products/multigov/overview.md
@@ -18,7 +18,6 @@ MultiGov expands DAO governance across blockchains, increasing participation, im
 - **Cross-chain proposal execution**: Approved proposals can be executed across multiple chains.
 - **Flexible architecture**: Can integrate with any Wormhole-supported blockchain.
 - **Upgradeable and extensible**: Supports upgrades across components while preserving vote history and system continuity.
-- **Backed by Tally**: Proposal creation, voting, and execution are coordinated via  [Tally](https://www.tally.xyz/get-started){target=\_blank}.
 
 ## How It Works
 

--- a/docs/products/multigov/tutorials/treasury-proposal.md
+++ b/docs/products/multigov/tutorials/treasury-proposal.md
@@ -211,7 +211,3 @@ governor.execute(targets, values, calldatas, descriptionHash);
     No direct return, but executing this function finalizes the cross-chain governance actions by dispatching the encoded messages via Wormhole to the spoke chains.
 
 Once the proposal is executed, the encoded messages will be dispatched via Wormhole to the spoke chains, where the Optimism and Arbitrum treasuries will receive their respective funds.
-
-## Conclusion
-
-Looking for more? Check out the [Wormhole Tutorial Demo repository](https://github.com/wormhole-foundation/demo-tutorials){target=\_blank} for additional examples.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -401,18 +401,12 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/wormhole
       name: Twitter
-    - icon: fontawesome/brands/discord
-      link: https://discord.com/invite/wormholecrypto
-      name: Discord
     - icon: telegram
       link: https://t.me/wormholecrypto
       name: Telegram
     - icon: fontawesome/brands/github
       link: https://github.com/wormhole-foundation/wormhole
       name: GitHub
-    - icon: docs
-      link: https://wormhole.com/docs/
-      name: Docs
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/@wormholecrypto
       name: YouTube


### PR DESCRIPTION
## Summary
- Remove Discord and self-referencing Docs icons from the site footer
- Remove all Tally platform references from MultiGov documentation (get-started, overview, FAQs, deploy-to-evm, timeline snippet)
- Remove redundant conclusion section from treasury proposal tutorial

## Test plan
- [ ] Verify site footer renders correctly with only X, Telegram, GitHub, and YouTube icons
- [ ] Verify MultiGov pages render without broken links or formatting issues
- [ ] Confirm no remaining Tally platform references in docs