### PR TITLE
docs: add Portal CCTP FAQ and update SDK/Connect versions

### DIFF
--- a/docs/products/token-transfers/wrapped-token-transfers/portal/faqs.md
+++ b/docs/products/token-transfers/wrapped-token-transfers/portal/faqs.md
@@ -50,3 +50,11 @@ While deploying tokens to new chains via Wormhole is fully permissionless, these
 
 - [**Basic Connect Demo**](https://github.com/wormhole-foundation/demo-basic-connect){target=\_blank}
 - [**NTT Connect Demo**](https://github.com/wormhole-foundation/demo-ntt-connect){target=\_blank}
+
+## Why is my CCTP transfer stuck and can't be redeemed?
+
+If your transfer is stuck and you're unable to complete it through Portal, it may have been initiated through a third-party app or smart contract that reserved the right to finalize it. In that case, Portal is unable to complete the redemption on your behalf. Only the original app can.
+
+To resolve this, go back to the app or platform you used to start the transfer and look for an option to complete or claim it there.
+
+If you want to investigate further, check the events of your originating transaction for a `destination_caller` field. If it's set to a non-zero address, that's the address exclusively authorized to redeem the message and the reason Portal can't complete it.

--- a/docs/variables.yml
+++ b/docs/variables.yml
@@ -6,7 +6,7 @@ ntt:
 repositories:
   wormhole_sdk:
     repository_url: https://github.com/wormhole-foundation/wormhole-sdk-ts
-    version: 4.13.1
+    version: 4.14.1
   wormhole:
     repository_url: https://github.com/wormhole-foundation/wormhole
     version: 2.56.0
@@ -18,7 +18,7 @@ repositories:
     version: 2.0.0+evm
   connect:
     repository_url: https://github.com/wormhole-foundation/wormhole-connect
-    version: 5.1.0
+    version: 5.1.1
   settlement:
     repository_url: https://github.com/mayan-finance/wormhole-sdk-route
     version: 1.26.0

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@wormhole-foundation/sdk": "4.13.1",
+        "@wormhole-foundation/sdk": "4.14.1",
         "axios": "^1.13.5",
         "sharp": "^0.34.5",
         "swagger-markdown": "^3.0.0"
@@ -167,9 +167,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1352,9 +1352,9 @@
       }
     },
     "node_modules/@injectivelabs/abacus-proto-ts-v2": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/abacus-proto-ts-v2/-/abacus-proto-ts-v2-1.17.4.tgz",
-      "integrity": "sha512-AVksEOLpMcK+ZQt1E/sXmG4FaZYaYJzXSx2xU4FgoY5Fc/tdA11KHx3Mjx/8OGJS5mTsscNSeV2cxipj1IbANg==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/abacus-proto-ts-v2/-/abacus-proto-ts-v2-1.17.5.tgz",
+      "integrity": "sha512-6/W2i87y1uqcBSlncBMLKyiBje2ZNf4/PmVN2baMS3irJzGkfmAuVj2aIVyDnhDJ/bxuS7pv5MPPFF1h0u0PTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.18.8.tgz",
-      "integrity": "sha512-SXe6bCXNvKcjJwKrRRMX6CBX7/Td4P0PHmMGAFbYzneYTMQpeP4XWDy0OxiXoxnHtT0YF2cHQBTSL2hdOyO1rg==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.18.13.tgz",
+      "integrity": "sha512-INWfKsLh9zeL/rCLmHdQrMWJl/NJ9A1v+AGSBR10xZMw5fFJuzi5gnPTSKUhpGnR7utfxgg7yQM/aP+hzhMG2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -1414,9 +1414,9 @@
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts-v2": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.18.6.tgz",
-      "integrity": "sha512-RknQB7tDQKDXGuQw/oGGoG95X7D+Hrwj9wcgDo4n22W9dnJsHqdWx+wUJgrvezGmmQBr9jvbcGRj+yPJw6E21g==",
+      "version": "1.18.10",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts-v2/-/indexer-proto-ts-v2-1.18.10.tgz",
+      "integrity": "sha512-6WfPg/8NTbfLt3nnzaeqIu98CV6d7mmQnALjCd8+79WP9b+KBGeDcONIaBIcZbp4+QbovbwT7lz9iL7ZbqpmLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1436,12 +1436,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.18.8.tgz",
-      "integrity": "sha512-VTh9cKPfFV1Zd4WXspAnEeRt7ENmdQf5pApeJkRpgBNxkZpInSwe/hQhMKi4EDPPF7TaMATg9VOn4wxRorI3fQ==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.18.13.tgz",
+      "integrity": "sha512-vRYxbEk6Nu3LP67mrl7niebXH2K3LScvRLV8ssaB3kjJ662w2FPizQMpEeJHc/nm6pPjVpcZ4YtH3bNsr6IhLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "1.18.8"
+        "@injectivelabs/ts-types": "1.18.13"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts-v2": {
@@ -1456,26 +1456,27 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.18.8.tgz",
-      "integrity": "sha512-ouIQMzdY39cd1/jOlr8+jz8kywA0o5tlL2m+GJEtcek2wgBZH7Gsn/5oiANcFoxsIVggABTEnek9k7UYIim4Tg==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.18.13.tgz",
+      "integrity": "sha512-U30lv165KE7lqQA1nb75xqgSh/RRhgucS3wbzUG6U/suZihyORsxTlHQlQKp17qVfF/Dg39kOc8xfiZczNSjrQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.33.0",
         "@cosmjs/proto-signing": "0.33.0",
         "@cosmjs/stargate": "0.33.0",
-        "@injectivelabs/abacus-proto-ts-v2": "1.17.4",
+        "@injectivelabs/abacus-proto-ts-v2": "1.17.5",
         "@injectivelabs/core-proto-ts-v2": "1.18.0",
-        "@injectivelabs/exceptions": "1.18.8",
+        "@injectivelabs/exceptions": "1.18.13",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts-v2": "1.18.6",
+        "@injectivelabs/indexer-proto-ts-v2": "1.18.10",
         "@injectivelabs/mito-proto-ts-v2": "1.17.3",
-        "@injectivelabs/networks": "1.18.8",
+        "@injectivelabs/networks": "1.18.13",
         "@injectivelabs/olp-proto-ts-v2": "1.17.6",
-        "@injectivelabs/ts-types": "1.18.8",
-        "@injectivelabs/utils": "1.18.8",
+        "@injectivelabs/tc-abacus-proto-ts-v2": "1.18.1",
+        "@injectivelabs/ts-types": "1.18.13",
+        "@injectivelabs/utils": "1.18.13",
         "@noble/curves": "^1.9.0",
         "@noble/hashes": "^1.8.0",
         "@protobuf-ts/grpcweb-transport": "^2.11.1",
@@ -1490,8 +1491,7 @@
         "http-status-codes": "^2.3.0",
         "rxjs": "7.8.2",
         "snakecase-keys": "^5.4.1",
-        "viem": "^2.41.2",
-        "ws": "^8.18.0"
+        "viem": "^2.41.2"
       }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/amino": {
@@ -1578,27 +1578,6 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/socket/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/stargate": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.0.tgz",
@@ -1648,42 +1627,32 @@
       "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
       "license": "Apache-2.0"
     },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+    "node_modules/@injectivelabs/tc-abacus-proto-ts-v2": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/tc-abacus-proto-ts-v2/-/tc-abacus-proto-ts-v2-1.18.1.tgz",
+      "integrity": "sha512-yyNvxMR45cdtr1XsJvhnf0awLgNaK7PWN5y0LRRwbd+DvBDWWKOqwG3efKIkjV/Z7AzC/jTI5+cpTwFFD/sIFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/grpcweb-transport": "^2.11.1",
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1"
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.18.8.tgz",
-      "integrity": "sha512-6P+abdWhoH7v40aUI3dvWHhrDXDvzyRqbSLFJOd6N94W8Ihiv5z12wPhOsTJsqTR2fxP6uOUuDz/jnPt/bHNqQ==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.18.13.tgz",
+      "integrity": "sha512-ggE5cx/s3SvYIoqcvndPTLC4swpR94RUh2hz0FpXcNfh9JuvPE5lhnVB4UTCZAgRTdT6IOe5fzCLFtVxLscnNg==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.18.8",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.18.8.tgz",
-      "integrity": "sha512-LLzVG08fvumUczzQtcSp16Yb+G3i/IcDXbMinuXszECynDI0tT6ICvNLt3kn8d8GwWpUmxiNraD113wz8w8naA==",
+      "version": "1.18.13",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.18.13.tgz",
+      "integrity": "sha512-7PPMJrQsscPRA3oFQ5c1dH/ph7WWBYRqbRcJlPKYU7N6RmbzzCIgF+l+IKi+Jy3jkwQWvxjGp5PPj2h2Oa+/iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "1.18.8",
-        "@injectivelabs/networks": "1.18.8",
-        "@injectivelabs/ts-types": "1.18.8",
+        "@injectivelabs/exceptions": "1.18.13",
+        "@injectivelabs/networks": "1.18.13",
+        "@injectivelabs/ts-types": "1.18.13",
         "axios": "^1.13.2",
         "bignumber.js": "^9.3.1",
         "http-status-codes": "^2.3.0",
@@ -2127,9 +2096,9 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.5.tgz",
-      "integrity": "sha512-4mAmr+AEhPYJ9TmDtxF3r3ZcbWy7W8kvZ4PoZYw/Xgp2J7WixjwTgiQZsoTDvch5nimmg3Ay6/0Kuh9oIvVs9A==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.6.tgz",
+      "integrity": "sha512-RzuOQDGd+EtR/cBYQAH/0jjaBzhyvXXGROhxigGJPf+q3XKyvtelZCucylzxiq5MaGlfBx1075djTsxFsFDgrA==",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -2350,56 +2319,56 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.13.1.tgz",
-      "integrity": "sha512-H0P9/0lNWcPvtb2lEioeZTfuwMlr19Wop8kwrjis1MFT1gDKLTM/NHvWgU6Vx1tXaDDgAyBdQx/0x2SrvlSM4Q==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-4.14.1.tgz",
+      "integrity": "sha512-A4C1R8YUIGn0oPKgwh9h4gcyaAYxF+IEQ/YVXgDiWNpoIJJVKCXTERRhUxaAEn3BopiMeCTPL3Jhj8bwttq1Fw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.13.1",
-        "@wormhole-foundation/sdk-algorand-core": "4.13.1",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-aptos": "4.13.1",
-        "@wormhole-foundation/sdk-aptos-cctp": "4.13.1",
-        "@wormhole-foundation/sdk-aptos-core": "4.13.1",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-base": "4.13.1",
-        "@wormhole-foundation/sdk-btc": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-definitions": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
-        "@wormhole-foundation/sdk-evm-cctp": "4.13.1",
-        "@wormhole-foundation/sdk-evm-core": "4.13.1",
-        "@wormhole-foundation/sdk-evm-portico": "4.13.1",
-        "@wormhole-foundation/sdk-evm-tbtc": "4.13.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-solana": "4.13.1",
-        "@wormhole-foundation/sdk-solana-cctp": "4.13.1",
-        "@wormhole-foundation/sdk-solana-core": "4.13.1",
-        "@wormhole-foundation/sdk-solana-tbtc": "4.13.1",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-stacks": "4.13.1",
-        "@wormhole-foundation/sdk-stacks-core": "4.13.1",
-        "@wormhole-foundation/sdk-sui": "4.13.1",
-        "@wormhole-foundation/sdk-sui-cctp": "4.13.1",
-        "@wormhole-foundation/sdk-sui-core": "4.13.1",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "4.13.1",
-        "@wormhole-foundation/sdk-xrpl": "4.13.1"
+        "@wormhole-foundation/sdk-algorand": "4.14.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.14.1",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-aptos": "4.14.1",
+        "@wormhole-foundation/sdk-aptos-cctp": "4.14.1",
+        "@wormhole-foundation/sdk-aptos-core": "4.14.1",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-base": "4.14.1",
+        "@wormhole-foundation/sdk-btc": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-definitions": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
+        "@wormhole-foundation/sdk-evm-cctp": "4.14.1",
+        "@wormhole-foundation/sdk-evm-core": "4.14.1",
+        "@wormhole-foundation/sdk-evm-portico": "4.14.1",
+        "@wormhole-foundation/sdk-evm-tbtc": "4.14.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-solana": "4.14.1",
+        "@wormhole-foundation/sdk-solana-cctp": "4.14.1",
+        "@wormhole-foundation/sdk-solana-core": "4.14.1",
+        "@wormhole-foundation/sdk-solana-tbtc": "4.14.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-stacks": "4.14.1",
+        "@wormhole-foundation/sdk-stacks-core": "4.14.1",
+        "@wormhole-foundation/sdk-sui": "4.14.1",
+        "@wormhole-foundation/sdk-sui-cctp": "4.14.1",
+        "@wormhole-foundation/sdk-sui-core": "4.14.1",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "4.14.1",
+        "@wormhole-foundation/sdk-xrpl": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.13.1.tgz",
-      "integrity": "sha512-E7ZItZrddQ8yOUG3rPJ2J4U0Gs9VfzYQ1Omx5Mv8nYxzSbGxU7/au8yZ++iTJNUH5S6jmJHCrkkvBikgE0d45g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-4.14.1.tgz",
+      "integrity": "sha512-qjhaul2R2LALyPDu/3kwQloFqVNcNzKhIOD52Yddbozw6+K/ZePpB8wKZVUhQI8npZGxRXhU/8Cfdk2T3ZuSQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -2407,89 +2376,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.13.1.tgz",
-      "integrity": "sha512-y9I3Jt3AsTVbBNbO2Pd9LKQnlaG1/etzKi6Se2bcOS9JlD/muILKubLhmafLgqi13OUQb7bfdlARrfI7/dXW9A==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-4.14.1.tgz",
+      "integrity": "sha512-IXi3TYR6mzJNHpLVI7i7QoSAzNyCR1g+poML5WQ/BoMzDhN8G9yc1JoOz27bZyvlhX2JTzJUmoRr0wLoIpVGNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-algorand": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-1VEcWdb9khdbD8fl2FlD4285cYzR3XkaZNyfbU+1qtmQ4Us+Xyjg138ESHO/2E+MRaVCtfi0lNvzvhbKs+LkYg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-a/qtOkZd8nuk0Sil5Zb/8VfqHLpP2Rsptcjdt0mk8dq8X93s28ZZp2MuAdGHRS0jWV25zj62s5ILPnmB+KkhPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "4.13.1",
-        "@wormhole-foundation/sdk-algorand-core": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-algorand": "4.14.1",
+        "@wormhole-foundation/sdk-algorand-core": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.13.1.tgz",
-      "integrity": "sha512-7U04rkmhwvZts26hGiROblNazKKI+W30p4UHdiHg5Tiqql9tEj05xGaH2zHhWzg5vd8W4IPBFA79JfeKclQvtA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-4.14.1.tgz",
+      "integrity": "sha512-1tq2WICSfB2E/yM3E8zJB6gD+2kk0TJZG+mMGNyIA3mhXoHK95rGvNdvuNd1nhFMfxpcEj+NZLi2dKWNwYSFcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.13.1.tgz",
-      "integrity": "sha512-k+GU8ti4q5umq8iVW8mv6wLXHRd7PuGfT1Jo9i5EYcamq2+fx9z0TVQIgKUajYhc3nxin5VKcxnqYKCWt4xGYQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-4.14.1.tgz",
+      "integrity": "sha512-VdlxRIkH/Z4CkxEucUH3H0Ce23ZaURMFcuAps/D+GsEldyoyBi7Ep5566z4LwpujGe0RPnBrrgM5qX+kKrrXvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-aptos": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.13.1.tgz",
-      "integrity": "sha512-UvIB9DmtTHQ8/SkwOiDvHodyozO12vNHq8zydS0K6AB3UUcdjoThqvjhMCGE68wkvipsnHZ9jKWlsZcDQuvY1w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-4.14.1.tgz",
+      "integrity": "sha512-Os5Lrw/voZ178Avbkic6QqtBMUNghkqaoCQZ/ENL0dCwc7utl7CjPRHDEF5DqGvm9FGjr0CZNs23ya+P3rH4Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-aptos": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-3moAOYLUjisuhIn8pErd+GneWZibMZmU18XfXogynAKyYB2kglG+Gmh7uz6aXhA2ePk8k/K59IrmJ05weTPBqA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-cb/SUlK3/askcKFlxGEcc3GW+WJC7wglaHHNwG0p42e9pYj8kLzyZJCVzo9M2pyoAZjmfe9yQ67HW194R6EmWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "4.13.1",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-aptos": "4.14.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.13.1.tgz",
-      "integrity": "sha512-oXZ3Dj7DlnhdHlAfMa4TAMTWRy7nz/FU7hT1/9Nl2v0TwTl2UX2U7u266sboEb4C6damMcMRjXR2P5hDcytw4w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-4.14.1.tgz",
+      "integrity": "sha512-S5VIItWYUvhLi1QTA1bgHHvgLMmo61VZPvp2f+Q2pVXbOY89oIX2DSSKU+0SVioFMWTkS5d5ZIOxIhHaUjZGnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -2497,25 +2466,25 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-btc": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-btc/-/sdk-btc-4.13.1.tgz",
-      "integrity": "sha512-5psm/56XIj5z8A69xCekX490qSByGKM/2tM7Dq3wlynNi81XqS9onYOJP63TQn4SG7ZVpeaJTDSbUDuOraPHaw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-btc/-/sdk-btc-4.14.1.tgz",
+      "integrity": "sha512-b44okmmfLLdxGtnSHzinWCja2pZv41QZ2EFljX94DjyYTedx5y7Ryh9ugK7z49XE0jRzUh4mWNjLZkVGrH1Snw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.13.1.tgz",
-      "integrity": "sha512-ZAgoWGIJ4CXCvu01TaBRSZz5rxMpV8DpCbvkun5y9+aZkvsOuV98R3Se3gglpXQYc7kTrbWagjmFo2xsOXOplA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-4.14.1.tgz",
+      "integrity": "sha512-v2tZm+OG2+UHKDdgdJ/6ctPckwq61ZLHPibaFLY46OWzv9BwvEGz2tT2lOm7XQTAs8bVhmh/avL56/cBlswQYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "4.13.1",
-        "@wormhole-foundation/sdk-definitions": "4.13.1",
+        "@wormhole-foundation/sdk-base": "4.14.1",
+        "@wormhole-foundation/sdk-definitions": "4.14.1",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -2523,16 +2492,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.13.1.tgz",
-      "integrity": "sha512-NQaSmMeZEwf6h6NYS638DC8RfMzEvAEt8b/a/YvD5HME+ILRrKh9iLEbwboHENDHhYGC03msDJfrXga1hnuydQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-4.14.1.tgz",
+      "integrity": "sha512-2BJWs4rzMvBBDvyEuh5stAhy+yVXCV29q//nV7JOughymq+TckRpI/fIyw/JmKWO/ZRODoSkm+MGKTDsNX8JHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2540,33 +2509,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.13.1.tgz",
-      "integrity": "sha512-8614HBvVMLa90eeW2kDzMWAPHVXibEjgrel7k7N/Kszq/C+8pUimtDXd+4JW5eMuYr8H/6xVxcsKludxHRu0NA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-4.14.1.tgz",
+      "integrity": "sha512-U0wQGa5uhx52IfvrLRmumUokKu20bhgneOS9GlbOsX+C1cnNXGuPgi/ooJ7/qPFc8YjCxw79q1XMVwrgj9nEuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.13.1.tgz",
-      "integrity": "sha512-IwjbPgFcsJg51Iex1ntahRzflBhWNVyQiRsIijkhtsSY6tmuwNmIDr8Q9M/Kd2/eRRAWlZNCYPh8kgwt1Za0Xw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-4.14.1.tgz",
+      "integrity": "sha512-e153qkr0pfcIaVbdRYyXvW+HFzGZvfNIhu6GNjk4MlKIg9B61jIvF9VXQ8ZvCOUBEul5PSabtKk0j05KB8Rrjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm-core": "4.14.1",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -2574,37 +2543,37 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-LB1QP0IYvBKNXeQrhYnr8wBc2SE6zwcMaqG6Wy5B8/CWY9tHDL3iK9x1Z2AfB/QENgFyc+U1VI5z9a0LkFEChg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-RNU0H+v3xujw55rgtxbHj9OmIS36F9+XRQm4kb+Xy1LN2UR0IasvjI8vxahXGi1Id5fwDz7lkWsGqpau2XFkxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-cosmwasm": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-cosmwasm": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.13.1.tgz",
-      "integrity": "sha512-/8X1q8zgmPTnjql5aoARpZ4jhdYSccx6pFLboVoJIPUSszSWDaMgUvGX2039mCp7KPGdV8SNMVrAPtR47ipZFA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-4.14.1.tgz",
+      "integrity": "sha512-o55cJG3QsvDmkS9SxeyZwvjHXHGGvbyzHDgvHxOwjO7+p+4HA9GVQyXMKqoQ2GQkYbKmUz76KAwISGDsn9M3ng==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "4.13.1"
+        "@wormhole-foundation/sdk-base": "4.14.1"
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.13.1.tgz",
-      "integrity": "sha512-24jrp8cH9Nlc1laN/TGihOiGkUjlYFVUNhXklHlsmCuzP0G9/mJKde2k9y/4u8qsgI/d3YxRAVscxADez4NqFw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-4.14.1.tgz",
+      "integrity": "sha512-TsXbWesNcSVy1SChGYttpl2r5/N+84smxYd7naMC1aT0udy8/WkaI9nf4qzpNoY2D4noVYyvOV5dMuAxdnAiQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2612,14 +2581,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.13.1.tgz",
-      "integrity": "sha512-XWtj6Oj56wL9UDGi1kU1FW6g1lcHNdaYBl9aSTMKOQU/kaEYZA4gEJ0gF5n9v2To+ZD7pGq6NRXQOiXYrzgjqg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-4.14.1.tgz",
+      "integrity": "sha512-FHIuC6fYzFvMyX3bGoR1MMVP3KdidvIBEDznUL7iSP2hRuybfDb8vUCgT4fY3KAw5sNalrYck/OdqFGRLk8EgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
-        "@wormhole-foundation/sdk-evm-core": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
+        "@wormhole-foundation/sdk-evm-core": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2627,13 +2596,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.13.1.tgz",
-      "integrity": "sha512-r/FGJYx6r1bhkO29GPG2c0QN0Oy2K+07g2idUWt2RdHWYlkDXgWQmtA04eKgyU5O5jPkXguJu8mA4lrXfyOUMg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-4.14.1.tgz",
+      "integrity": "sha512-t2sCwTNegxq1qp6/nQMbyIFZLb/TMaoLGNdR5Q+RxNZ4B4IYlxj8nGy1GUL5oYMSLnbJrg1kSVosO3H7p9/77Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2641,15 +2610,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.13.1.tgz",
-      "integrity": "sha512-Hs0slWmdcn74nzS3vlaNNPE38opaZew9CvMi476YdOCv6UNUIMTqQiYbJERTiI7X9d7BS+w3CVmORg5njMkwww==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-4.14.1.tgz",
+      "integrity": "sha512-zy0UeYm0BDpBgePL29X4G9HUGQjcpN+gYJiUWIv0VnoKwuZ5m60gDKkmgX1HOEawg2RhmIwA7LnIGO101sNSdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
-        "@wormhole-foundation/sdk-evm-core": "4.13.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
+        "@wormhole-foundation/sdk-evm-core": "4.14.1",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2657,14 +2626,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.13.1.tgz",
-      "integrity": "sha512-tj7Ak8m/F3t/B5iWTYGuOMWvSGuum6G1su/NX9w1q3FJvfDRnQXwsZVyw/byCRY7Ovd80PNFNnJlHo1/wpPE9w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-4.14.1.tgz",
+      "integrity": "sha512-PmaIzxy0eENrGuMkIJT7/EXHXipeNkJRaOVZORhRPeiJBgRLm0t6THKxVfx65Et8zCF7e+arDIfMtbsNWAYRBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
-        "@wormhole-foundation/sdk-evm-core": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
+        "@wormhole-foundation/sdk-evm-core": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2672,14 +2641,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-ctHwgjhC4k9YpSPPwbtvrifmI8gPr2rHsTS9yol5c1iHXKuaYV8TSyFJbJriRYb31Mf8sqeODSDHfTNSrz2GUQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-KMRWmwbsC2MyHUCynqRmKogEmiu3SwgYm0rYSLQf2I4WGVAFan3Kq4Jyj8WLRKBQzDm1ly+LTCSRFzlxRA9GQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-evm": "4.13.1",
-        "@wormhole-foundation/sdk-evm-core": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-evm": "4.14.1",
+        "@wormhole-foundation/sdk-evm-core": "4.14.1",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -2687,16 +2656,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.13.1.tgz",
-      "integrity": "sha512-9gV8qQaEXHYd+WbCx9wn1ZcPslfKGAewV06llrtaLPCTGq1vPA0lPPyeNeEwwrIHsv8aNFABF+Vm17eKWnK1TA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-4.14.1.tgz",
+      "integrity": "sha512-ufby+0bJBP2UNoEqKAHaaOJ74XNt9V3xifZ48ohOW7KGVgRrkMoinn1SUiqy+PKBuvjB3RBrIAeqEfdWGiDOhA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -2704,162 +2673,162 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.13.1.tgz",
-      "integrity": "sha512-N7jGhD3Fwt9ZKBgx01YOGKPJJyU9jmgP+GdyBG8LVFWhmki1VcKAs7AoijYyWmsUcuSjI2PuvmRvc3wLP0K8aQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-4.14.1.tgz",
+      "integrity": "sha512-OdVvtBOXSKbsRCXBl0ULMOZEdgIXFPkGzkpCaY0hOLqw5dJxbk3a6ahATsyDScSbKROZk27aIJi/5I+oWfd7iQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-solana": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-solana": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.13.1.tgz",
-      "integrity": "sha512-gcOvdKxMip2uKcgOHgUNH4NuWkw65XPC4hCn84COoglTx0NCQ4XfZARSy16Q14CzQqh/J+xSIpdFk7ER22oB0w==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-4.14.1.tgz",
+      "integrity": "sha512-e6OFXkev1U5dnxnZCdNVrCKealP2rVGHip9bgDOR9a70fiwB3u1Okn5qkSlEgOYuKub5C8I+3g9qCjvzqs96aA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-solana": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-solana": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.13.1.tgz",
-      "integrity": "sha512-LrqmizRQ7wMstOudGDG/5Bhoeafy9fCk4Fsid/NQ3XKuY+ckvHR9HJUIEvG9Gi/8SdQ3+my8qyXoRAYap7AkpA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-4.14.1.tgz",
+      "integrity": "sha512-DAzoY+pW6q43ukwvriNRfW7U/CS/aX7wXgkjMxA6WNzqtXexJe1+HXqwrsR+Tgv3ageTUNLZFVDQ8mdIv41r9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-solana": "4.13.1",
-        "@wormhole-foundation/sdk-solana-core": "4.13.1",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-solana": "4.14.1",
+        "@wormhole-foundation/sdk-solana-core": "4.14.1",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-jhMVoPxQhmwqvdovqGcZ704+5+ajdRkr+tS6qOZeCwHK6wyBwYjS9sMGRiMyDKuOA2CZ0HpDU4BP6lmzGpd3wg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-2pjpUW/VHhFKHjCgrP1Us/vWMbOMiN2PbcmVT14qo9t+kS0H4tURfFyF+BDdbts6YXHp2w77/Uz/UdXeHN3jUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-solana": "4.13.1",
-        "@wormhole-foundation/sdk-solana-core": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-solana": "4.14.1",
+        "@wormhole-foundation/sdk-solana-core": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.13.1.tgz",
-      "integrity": "sha512-ptFhvojQgn/6v+0RMDHj7ti7gz22jiHEKrmtkrANj/PTQDRxzt7tk3w3pBOpClBuZLds/iLkpFyGVCuQKeiU/g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks/-/sdk-stacks-4.14.1.tgz",
+      "integrity": "sha512-ZmE7DbojIRJdZmVFU5ZkSPKD0VXI7w3mLjl3USxa+zi7JRPANTUqC0chl0ri0QBZByjVUXRzSyF3rF9n9i+Szg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stacks/network": "^7.0.2",
         "@stacks/transactions": "^7.1.0",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-stacks-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.13.1.tgz",
-      "integrity": "sha512-ABdTqKkTELiabyLDX1hNDdpFBw15igOPECVw5jqT9VyzVOZQoqJYIB2RASqDWWN0eqVenKmraYdiCh8z0pjKLA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-stacks-core/-/sdk-stacks-core-4.14.1.tgz",
+      "integrity": "sha512-tlwAPxP2557L9JEI51FtZZNuVPVtOvZZYUb9Fy8EfKxNljTqXDW46iDjDoVGgaDy83o8O1vi5dkX7NpO1F1x/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-stacks": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-stacks": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.13.1.tgz",
-      "integrity": "sha512-GHXSrx6LTLjsqVrNvmvT3Tq6DbSuvsG5MvSlPC7MLC/W0cTVsm2dq5h0lbswLc66WzM4y0AT7knlo+hZL0aTIg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-4.14.1.tgz",
+      "integrity": "sha512-sZfrsq+XHimKaA1DyHaHkaMLqynG4nPFdZtU4xT7IYuC6UzDeN5A6u2kg5EHf9db6HOlgxL36SVKqv/uh30suA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.13.1.tgz",
-      "integrity": "sha512-4SF/tCqPQxK8wnGQmFl28sqt8HdHm5nBCZYeVI+bdtz8KcnBt4B7viG3DQ2T14eqdpVlTc+6GhggDqNx8kMtSA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-4.14.1.tgz",
+      "integrity": "sha512-T09qTnrwYzHUKinQ/MNmGrewRpWZrkwKS/SiJQMk5G9oLoJLd3jPfg6KLIbzf3zPDMo6s8Tj7UyuJHzumZxtug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-sui": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-sui": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.13.1.tgz",
-      "integrity": "sha512-lFR0IuO0EJssv3bJ1+lB+2x+QkOt96md5G+lt/Qbeq2WUEOnk9LTu35oVXdHI9Njzv3Z0JkxPvRzjDuOYkWU4A==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-4.14.1.tgz",
+      "integrity": "sha512-h1LAmQAbqtgOLi+OpCW35P2Mc7g7dgB7yHDyPSptZu8rZraHfANFMpZ9bJqiEq04M6VbaE9vW5Ijidr0MwpUiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-sui": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-sui": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.13.1.tgz",
-      "integrity": "sha512-0+h2TyTylUUiS3u9OephDlEUKy4XMWMqrzgeuM9znnxqZOlI+7ZfR5VJ82ucN1IygFdoikFDxmiPBTptSwJbxQ==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-4.14.1.tgz",
+      "integrity": "sha512-GYI/6V98WJOffFA4h8lMrmRQbYjo0QvO2d6iSG54pLbQxBP24hV2OylyFx14smuMlf25NeusEXKQBXlltfvtUg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.37.2",
-        "@wormhole-foundation/sdk-connect": "4.13.1",
-        "@wormhole-foundation/sdk-sui": "4.13.1",
-        "@wormhole-foundation/sdk-sui-core": "4.13.1"
+        "@wormhole-foundation/sdk-connect": "4.14.1",
+        "@wormhole-foundation/sdk-sui": "4.14.1",
+        "@wormhole-foundation/sdk-sui-core": "4.14.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-xrpl": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-xrpl/-/sdk-xrpl-4.13.1.tgz",
-      "integrity": "sha512-4JbcVCx8Kqxqn/1Ytugf+J4IduJ0TRdLbdupIIG9mkcIJDvuqYY0/n7apv4tKKwCAQRsQEPF3QaIDeCnSvukhg==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-xrpl/-/sdk-xrpl-4.14.1.tgz",
+      "integrity": "sha512-FdbGj+bH0+063kXb5w1+sxtOiwF3FTIjwstn8C6MS5cTlClHJDU/hySXYP387rim8Avg+CAdNj0AIxZM66XbeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "4.13.1",
+        "@wormhole-foundation/sdk-connect": "4.14.1",
         "xrpl": "^4.2.0"
       },
       "engines": {
@@ -4996,9 +4965,9 @@
       "peer": true
     },
     "node_modules/ox": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.0.tgz",
-      "integrity": "sha512-WLOB7IKnmI3Ol6RAqY7CJdZKl8QaI44LN91OGF1061YIeN6bL5IsFcdp7+oQShRyamE/8fW/CBRWhJAOzI35Dw==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.5.tgz",
+      "integrity": "sha512-HgmHmBveYO40H/R3K6TMrwYtHsx/u6TAB+GpZlgJCoW0Sq5Ttpjih0IZZiwGQw7T6vdW4IAyobYrE2mdAvyF8Q==",
       "funding": [
         {
           "type": "github",
@@ -5700,9 +5669,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -5724,9 +5693,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.2.tgz",
-      "integrity": "sha512-etDIwDgmDiGaPg8rUbJtUFuC3/nAJCbhMYyfh5dOcqNNkzBWTNcS2VluPSM5JVo+9U3b2hle2RkBEq3+xyvlvg==",
+      "version": "2.47.5",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.5.tgz",
+      "integrity": "sha512-nVrJEQ8GL4JoVIrMBF3wwpTUZun0cpojfnOZ+96GtDWhqxZkVdy6vOEgu+jwfXqfTA/+wrR+YsN9TBQmhDUk0g==",
       "funding": [
         {
           "type": "github",
@@ -5741,7 +5710,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.0",
+        "ox": "0.14.5",
         "ws": "8.18.3"
       },
       "peerDependencies": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@wormhole-foundation/sdk": "4.13.1",
+    "@wormhole-foundation/sdk": "4.14.1",
     "axios": "^1.13.5",
     "sharp": "^0.34.5",
     "swagger-markdown": "^3.0.0"


### PR DESCRIPTION
## Summary
- Add FAQ entry to Portal Bridge FAQs explaining why CCTP transfers may be stuck due to `destination_caller` restrictions
- Update `wormhole-sdk-ts` from 4.13.1 → 4.14.1 (closes #842)
- Update `wormhole-connect` from 5.1.0 → 5.1.1 (closes #843)

## Test plan
- [ ] Verify Portal FAQ page renders correctly with the new entry
- [ ] Confirm version variables propagate correctly in docs referencing SDK and Connect versions