### PR TITLE
docs: fix broken Reference nav link

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,5 +2,5 @@ nav:
 - products
 - protocol
 - tools
-- 'Reference': '/docs/products/reference/chain-ids/'
+- 'Reference': '/products/reference/chain-ids/'
 - ai-resources


### PR DESCRIPTION
## Summary
- The Reference tab in the top navigation linked to `/docs/products/reference/chain-ids/`, but MkDocs already prepends `/docs` from `site_url`, resulting in a doubled path (`/docs/docs/products/...`) that returns a 404 with a broken page.
- Removed the extra `/docs` prefix from the link in `docs/.nav.yml`.

## Test plan
- [ ] Verify the Reference tab in the top nav links to the correct chain IDs page
- [ ] Confirm the page renders correctly at `https://docs.wormhole.com/products/reference/chain-ids/`