### PR TITLE
docs: fix Reference nav link to use relative URL

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -2,5 +2,5 @@ nav:
 - products
 - protocol
 - tools
-- 'Reference': '/products/reference/chain-ids/'
+- 'Reference': 'https://wormhole.com/docs/products/reference/chain-ids/'
 - ai-resources


### PR DESCRIPTION
## Summary
- The Reference tab used a path-based URL (`/products/reference/chain-ids/`) that broke depending on the serving domain.
- Replaced with the full canonical URL (`https://wormhole.com/docs/products/reference/chain-ids/`).
- MkDocs treats full URLs as external links (DEBUG level), so this passes `--strict` without any validation changes.

## Verified locally
- `mkdocs build --strict` passes (zero non-cairosvg warnings)
- Tab label shows "Reference"
- Tab links to the correct canonical URL
- Sidebar and page content unaffected

## Test plan
- [ ] Verify the Reference tab works on the Cloudflare preview
- [ ] Verify sidebar shows all reference pages
- [ ] CI build check passes