### PR TITLE
docs: improve NTT Token2022 Support

### DIFF
--- a/docs/products/token-transfers/native-token-transfers/overview.md
+++ b/docs/products/token-transfers/native-token-transfers/overview.md
@@ -16,6 +16,14 @@ Native Token Transfers (NTT) provides an adaptable framework for transferring yo
 - **No wrapped tokens**: Tokens are used directly within their native ecosystem, eliminating intermediary transfer steps.
 
 
+
+### Supported Token Standards
+
+- **EVM Chains**: ERC-20 tokens
+- **SVM Chains**: Standard SPL tokens (Note: Token2022 is not currently supported)
+- **Sui**: Sui Coin standard
+
+NTT does not support Token2022, token extensions, or other non-standard token implementations.
 ## Deployment Models
 
 NTT offers two operational modes for your existing tokens: 


### PR DESCRIPTION
## What changed

- **`docs/products/token-transfers/native-token-transfers/overview.md`** (Key Features): add

## Why

Add clarity about supported token standards for Native Token Transfers. The documentation should explicitly list which token standards are supported on each chain type (ERC-20 on EVM, SPL on Solana but not Token2022).

<!-- wormhole-docs-improver-topic:72892019a5f5 -->
---
*Automated PR created by wormhole-docs-improver.*