### PR TITLE
docs: restore Messaging in Products nav and drop Queries links

### DIFF
--- a/docs/products/.nav.yml
+++ b/docs/products/.nav.yml
@@ -3,4 +3,5 @@ nav:
  - token-transfers
  - connect
  - settlement
+ - messaging
  - reference

--- a/docs/products/messaging/overview.md
+++ b/docs/products/messaging/overview.md
@@ -33,12 +33,10 @@ Wormhole Messaging enables a wide range of multichain applications. Below are co
 
     - **[Messaging](/docs/products/messaging/get-started/){target=\_blank}**: Coordinate actions across chains.
     - **[Native Token Transfers](/docs/products/token-transfers/native-token-transfers/overview/){target=\_blank}**: Transfer collateral as native assets.
-    - **[Queries](/docs/products/queries/overview/){target=\_blank}**: Fetch rates and prices in real-time.
 
 - **Oracle Networks (e.g., [Pyth](https://wormhole.com/case-studies/pyth){target=\_blank})**
 
     - **[Messaging](/docs/products/messaging/get-started/){target=\_blank}**: Relay verified data.
-    - **[Queries](/docs/products/queries/overview/){target=\_blank}**: Aggregate multi-chain sources.
 
 - **Gas Abstraction**
 

--- a/docs/products/messaging/overview.md
+++ b/docs/products/messaging/overview.md
@@ -23,7 +23,7 @@ The messaging flow consists of several core components:
 3. **Relayers (Executor)**: Off-chain or on-chain relayers transport the VAA to the destination chain. In Wormhole’s architecture, this role is fulfilled by the [**Executor**](/docs/products/messaging/concepts/executor-overview/){target=\_blank}, a permissionless, shared framework that standardizes message delivery across all supported chains.
 4. **Target chain (recipient contract)**: The [Core Contract](/docs/protocol/infrastructure/core-contracts/){target=\_blank} on the destination chain verifies the VAA and triggers the specified application logic.
 
-![Wormhole architecture detailed diagram: source to target chain communication.](/docs/images/protocol/architecture/architecture-1.webp)
+![Wormhole architecture detailed diagram: source to target chain communication.](/images/protocol/architecture/architecture-1.webp)
 
 ## Use Cases
 

--- a/docs/products/messaging/overview.md
+++ b/docs/products/messaging/overview.md
@@ -23,7 +23,7 @@ The messaging flow consists of several core components:
 3. **Relayers (Executor)**: Off-chain or on-chain relayers transport the VAA to the destination chain. In Wormhole’s architecture, this role is fulfilled by the [**Executor**](/docs/products/messaging/concepts/executor-overview/){target=\_blank}, a permissionless, shared framework that standardizes message delivery across all supported chains.
 4. **Target chain (recipient contract)**: The [Core Contract](/docs/protocol/infrastructure/core-contracts/){target=\_blank} on the destination chain verifies the VAA and triggers the specified application logic.
 
-![Wormhole architecture detailed diagram: source to target chain communication.](/images/protocol/architecture/architecture-1.webp)
+![Wormhole architecture detailed diagram: source to target chain communication.](/docs/images/protocol/architecture/architecture-1.webp)
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary
- Restore `messaging` to `docs/products/.nav.yml` so it reappears in the Products left-hand nav.
- Remove two Queries links from `docs/products/messaging/overview.md` use cases (Borrowing/Lending and Oracle Networks).

## Test plan
- [x] Verify Messaging appears in the Products sidebar
- [x] Confirm no Queries links remain in messaging overview or sub-pages