### PR TITLE
docs: wormchain ibc contract for guardians ref

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         if: steps.auth.outputs.authorized == 'true'
-        uses: anthropics/claude-code-action@ade221fd1c400376a4799977d683a4eda09f9d7c # v1.0.60
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1.0.159
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use the workflow token directly so the action does not need OIDC.

--- a/docs/products/reference/contract-addresses.md
+++ b/docs/products/reference/contract-addresses.md
@@ -43,7 +43,7 @@ categories: Reference
 --8<-- 'text/products/reference/contract-addresses/wh-quoter-implementation.md'
 
 --8<-- 'text/products/reference/contract-addresses/quoter-public-keys.md'
-    
+
 ## Guardian Governance
 
 --8<-- 'text/products/reference/contract-addresses/governance.md'
@@ -65,9 +65,17 @@ categories: Reference
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Ethereum</td><td><code>0x1462800febd49232798132e8c8b721aa86c4c209</code></td></tr></tbody></table>
 
+## IBC
+
+This configuration is for the `ibc` feature for guardians.
+
+=== "Mainnet"
+
+    <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Wormchain</td><td><code>wormhole1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5ws2y050r</code></td></tr></tbody></table>
+
 ## Read-Only Deployments
 
 --8<-- 'text/products/reference/contract-addresses/read-only.md'
 
-!!! note  
+!!! note
     Read-only deployments allow Wormhole messages to be received on chains not fully integrated with Wormhole Guardians. These deployments support cross-chain data verification but cannot originate messages. For example, a governance message can be sent from a fully integrated chain and processed on a read-only chain, but the read-only chain cannot send messages back.


### PR DESCRIPTION
### Description

Document the wormchain ibc mainnet contract address. After this is merged, I can update [these guardian docs](https://github.com/wormhole-foundation/wormhole/blob/main/docs/operations.md#enabling-ibc) with a link to here for the value for the ibc contract address.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [x] If pages have been moved, I have created redirects in `mkdocs.yml`
