### PR TITLE
docs: add gateway contract for guardian setup

### DIFF
--- a/docs/products/connect/configuration/data.md
+++ b/docs/products/connect/configuration/data.md
@@ -52,7 +52,7 @@ Connect lets you customize the available chains to match your project's needs. Y
 
 By default, Connect offers two bridging protocols: Wrapped Token Transfers (WTT) and Circle's CCTP (for native USDC). For most use cases, integrators require more than these default routes. The `routes` property allows you to specify which protocols to include and exclude any routes unnecessary for your application, including default and third-party routes.
 
-!!! note "Terminology" 
+!!! note "Terminology"
     The SDK and smart contracts use the name Token Bridge. In documentation, this product is referred to as Wrapped Token Transfers (WTT). Both terms describe the same protocol.
 
 #### Available Route Plugins
@@ -60,7 +60,7 @@ By default, Connect offers two bridging protocols: Wrapped Token Transfers (WTT)
 The `@wormhole-foundation/wormhole-connect` package offers a variety of `route` plugins to give you flexibility in handling different protocols. You can choose from the following `route` exports for your integration:
 
 - **[`TokenBridgeRoute`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/tokenBridge/manual.ts){target=\_blank}**: Manually redeemed Wormhole WTT route.
-- **[`AutomaticTokenBridgeRoute`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/tokenBridge/automatic.ts){target=\_blank}**: Automatically redeemed (relayed) WTT route.
+- **[`ExecutorTokenBridgeRoute`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/tokenBridge/executor.ts){target=\_blank}**: Executor.
 - **[`CCTPRoute`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/cctp/manual.ts){target=\_blank}**: Manually redeemed CCTP route.
 - **[`AutomaticCCTPRoute`](https://github.com/wormhole-foundation/wormhole-sdk-ts/blob/main/connect/src/routes/cctp/automatic.ts){target=\_blank}**: Automatically redeemed (relayed) CCTP route.
 - **`DEFAULT_ROUTES`**: Array containing the four preceding routes (`TokenBridgeRoute`, `AutomaticTokenBridgeRoute`, `CCTPRoute`, `AutomaticCCTPRoute`).

--- a/docs/products/reference/contract-addresses.md
+++ b/docs/products/reference/contract-addresses.md
@@ -73,6 +73,14 @@ This configuration is for the `ibc` feature for guardians.
 
     <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Wormchain</td><td><code>wormhole1wkwy0xh89ksdgj9hr347dyd2dw7zesmtrue6kfzyml4vdtz6e5ws2y050r</code></td></tr></tbody></table>
 
+## Gateway
+
+This configuration is for the `gatewayContract` guardian configuration.
+
+=== "Mainnet"
+
+    <table data-full-width="true" markdown><thead><tr><th>Chain Name</th><th>Contract Address</th></tr></thead><tbody><tr><td>Wormchain</td><td><code>wormhole1ufs3tlq4umljk0qfe8k5ya0x6hpavn897u2cnf9k0en9jr7qarqqaqfk2j</code></td></tr></tbody></table>
+
 ## Read-Only Deployments
 
 --8<-- 'text/products/reference/contract-addresses/read-only.md'


### PR DESCRIPTION
Flags would look something like:

    --gatewayLCD=http://<your_wormchain_validator>:1317
    --gatewayWS=ws://<your_wormchain_validator>:26657/websocket
    --gatewayContract=wormhole1ufs3tlq4umljk0qfe8k5ya0x6hpavn897u2cnf9k0en9jr7qarqqaqfk2j

### Description

Please explain the changes this PR addresses here.

### Checklist

- [x] **Required** - I have added a label to this PR 🏷️
- [X] **Required** - I have run my changes through Grammarly
- [X] If pages have been moved, I have created redirects in `mkdocs.yml`
