### PR TITLE
docs: link OpenChainBench VAA finalization latency benchmark

### DIFF
--- a/docs/protocol/infrastructure/vaas.md
+++ b/docs/protocol/infrastructure/vaas.md
@@ -54,6 +54,10 @@ The consistency level determines whether Guardians wait for a chain's final comm
 
 Guardian watchers are specialized processes that monitor each blockchain in real-time. They enforce the selected consistency level by deciding whether enough commitment has been reached before signing and emitting a VAA. Some chains allow only one commitment level (effectively final), while others let integrators pick between near-final or fully finalized states. Choosing a faster option speeds up VAA production but increases reorg risk. A more conservative option takes longer but reduces the likelihood of rollback.
 
+### Observed Finalization Latency
+
+For a public, passive view of how long VAAs actually take to finalize per source chain, [OpenChainBench](https://openchainbench.com/benchmarks/wormhole-vaa-latency){target=\_blank} publishes an open benchmark computed from the [Wormholescan API](https://docs.wormholescan.io/){target=\_blank}. The benchmark polls `/api/v1/vaas` every 60 seconds and records `indexedAt - timestamp` per VAA as a Prometheus histogram bucketed by `emitterChain`. Source code is available on [GitHub](https://github.com/ChainBench/openchainbench){target=\_blank}.
+
 ## Signatures
 
 The body of the VAA is hashed twice with `keccak256` to produce the signed digest message.


### PR DESCRIPTION
## Summary

Adds a short subsection under `Consistency and Finality` in `docs/protocol/infrastructure/vaas.md` linking to a public, passive observation benchmark of VAA finalization latency by source chain.

The benchmark is computed from the public Wormholescan API (`/api/v1/vaas`) at 60s poll cadence, records `indexedAt - timestamp` per VAA as a Prometheus histogram bucketed by `emitterChain`, and covers roughly 20 source chains. It runs zero canary transactions and issues no writes against Guardian or Wormholescan infrastructure.

- Benchmark: https://openchainbench.com/benchmarks/wormhole-vaa-latency
- Source: https://github.com/ChainBench/openchainbench

Current sample values: Sui ~4-8s, BNB ~5-10s, Polygon ~10-15s, Solana ~15-25s, Ethereum ~15-30s.

## Precedent

Similar minimal doc-link contributions previously merged upstream by other chain and protocol projects:

- osmosis-labs/docs#349
- jup-ag/docs#939
- InjectiveLabs/injective-docs#182
- neutron-org/neutron-docs#313
- inkonchain/docs#632
- kaiachain/kaia-docs#437

## Change

4 lines added to `docs/protocol/infrastructure/vaas.md` as a new `### Observed Finalization Latency` subsection under `## Consistency and Finality`. Uses the existing MkDocs Material link style (`{target=\_blank}`). No new dependencies, no navigation changes, no components introduced.

## Disclosure

I maintain OpenChainBench. No affiliation with Wormhole Foundation. Happy to relocate the section, reword, or drop the GitHub source link if preferred.